### PR TITLE
fix: emitting onError when defined cache fails

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -208,18 +208,22 @@ class Wrapper {
   }
 
   add (args) {
-    const key = this.getKey(args)
+    try {
+      const key = this.getKey(args)
 
-    let query = this.dedupes.get(key)
-    if (!query) {
-      query = new Query()
-      this.buildPromise(query, args, key)
-      this.dedupes.set(key, query)
-    } else {
-      this.onDedupe(key)
+      let query = this.dedupes.get(key)
+      if (!query) {
+        query = new Query()
+        this.buildPromise(query, args, key)
+        this.dedupes.set(key, query)
+      } else {
+        this.onDedupe(key)
+      }
+
+      return query.promise
+    } catch (err) {
+      this.onError(err)
     }
-
-    return query.promise
   }
 
   /**

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -582,7 +582,7 @@ test('calls onError listener', async (t) => {
 })
 
 test('should call onError when serialize throws exception', async (t) => {
-  t.plan(2)
+  t.plan(1)
 
   const serialize = () => {
     throw new Error('error serializing')
@@ -590,14 +590,8 @@ test('should call onError when serialize throws exception', async (t) => {
 
   const onError = err => t.equal(err.message, 'error serializing')
 
-  // onError in Cache options
   const cache = new Cache({ storage: createStorage(), onError })
   cache.define('serializeWithError', { serialize }, async k => k)
 
-  // onError in define options
-  const cache2 = new Cache({ storage: createStorage() })
-  cache2.define('serializeWithError', { serialize, onError }, async k => k)
-
   await cache.serializeWithError(1)
-  await cache2.serializeWithError(1)
 })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -580,3 +580,24 @@ test('calls onError listener', async (t) => {
     t.equal(err.message, 'whoops')
   }
 })
+
+test('should call onError when serialize throws exception', async (t) => {
+  t.plan(2)
+
+  const serialize = () => {
+    throw new Error('error serializing')
+  }
+
+  const onError = err => t.equal(err.message, 'error serializing')
+
+  // onError in Cache options
+  const cache = new Cache({ storage: createStorage(), onError })
+  cache.define('serializeWithError', { serialize }, async k => k)
+
+  // onError in define options
+  const cache2 = new Cache({ storage: createStorage() })
+  cache2.define('serializeWithError', { serialize, onError }, async k => k)
+
+  await cache.serializeWithError(1)
+  await cache2.serializeWithError(1)
+})


### PR DESCRIPTION
When `serialize` throws an error onEmit wasn't being called.
Putting `try catch` when `add` function is called we can call `onError` when it throws exception.

Closes #16 