### PR TITLE
fix #30 function ttl of 0 is overwritten by global ttl

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -100,7 +100,7 @@ class Cache {
       storage = this[kStorage]
     }
 
-    const ttl = opts.ttl || this[kTTL]
+    const ttl = opts.ttl !== undefined ? opts.ttl : this[kTTL]
     const onDedupe = opts.onDedupe || this[kOnDedupe]
     const onError = opts.onError || this[kOnError]
     const onHit = opts.onHit || this[kOnHit]

--- a/test/ttl.test.js
+++ b/test/ttl.test.js
@@ -74,3 +74,20 @@ test('do not cache failures', async (t) => {
   await t.rejects(cache.fetchSomething(42))
   t.same(await cache.fetchSomething(42), { k: 42 })
 })
+
+test('function ttl has precedence over global ttl', async (t) => {
+  t.plan(1)
+
+  const cache = new Cache({ ttl: 42, storage: createStorage() })
+
+  let callCount = 0
+  cache.define('fetchSomething', { ttl: 0 }, async (query) => {
+    callCount += 1
+    return { k: query }
+  })
+
+  await cache.fetchSomething(42)
+  await cache.fetchSomething(42)
+
+  t.same(callCount, 2)
+})


### PR DESCRIPTION
The global cache TTL takes precedence over the more specific function
TTL when the function TTL is 0.

A sample case that shows this problem is

```
$ cat example.mjs
import { createCache } from 'async-cache-dedupe'

const cache = createCache({
  ttl: 5,
  storage: { type: 'memory' },
})

cache.define('fetchSomething', { ttl: 0 }, async (k) => {
  console.log('query', k)
  return { k }
})

await cache.fetchSomething(1)
await cache.fetchSomething(1)
await cache.fetchSomething(1)
```

The output of this script should be

```
$ node example.mjs
query 1
query 1
query 1
```

but in v1.2.2 it displays the following

```
$ node example.mjs
query 1
```