### PR TITLE
fix: error handling in references function

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
   "license": "MIT",
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
-    "ioredis": "^5.0.1",
+    "ioredis": "^5.2.3",
     "proxyquire": "^2.1.3",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
-    "tap": "^16.2.0"
+    "tap": "^16.3.0"
   },
   "dependencies": {
     "abstract-logging": "^2.0.1",
-    "mnemonist": "^0.39.0",
-    "safe-stable-stringify": "^2.2.0"
+    "mnemonist": "^0.39.2",
+    "safe-stable-stringify": "^2.3.1"
   },
   "standard": {
     "ignore": [

--- a/src/cache.js
+++ b/src/cache.js
@@ -261,10 +261,14 @@ class Wrapper {
       return result
     }
 
-    let references = this.references(args, key, result)
-    if (references && typeof references.then === 'function') { references = await references }
-    // TODO validate references?
-    await this.storage.set(storageKey, result, this.ttl, references)
+    try {
+      let references = this.references(args, key, result)
+      if (references && typeof references.then === 'function') { references = await references }
+      // TODO validate references?
+      await this.storage.set(storageKey, result, this.ttl, references)
+    } catch (e) {
+      // onError()
+    }
 
     return result
   }

--- a/src/cache.js
+++ b/src/cache.js
@@ -266,8 +266,8 @@ class Wrapper {
       if (references && typeof references.then === 'function') { references = await references }
       // TODO validate references?
       await this.storage.set(storageKey, result, this.ttl, references)
-    } catch (e) {
-      // onError()
+    } catch (err) {
+      this.onError(err)
     }
 
     return result

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -491,6 +491,28 @@ test('should cache with references', async function (t) {
   await cache.run(1)
 })
 
+test('should handle error throwing in references function (sync)', async function (t) {
+  const cache = new Cache({ ttl: 60, storage: createStorage() })
+
+  cache.define('references', {
+    references: (args, key, result) => { throw new Error('boom') }
+  }, () => 'the-result')
+
+  t.equal(await cache.references(1), 'the-result')
+  t.equal(await cache.references(1), 'the-result')
+})
+
+test('should handle error throwing in references function (async)', async function (t) {
+  const cache = new Cache({ ttl: 60, storage: createStorage() })
+
+  cache.define('references', {
+    references: async (args, key, result) => { throw new Error('boom') }
+  }, () => 'the-result')
+
+  t.equal(await cache.references(1), 'the-result')
+  t.equal(await cache.references(1), 'the-result')
+})
+
 test('should cache with async references', async function (t) {
   t.plan(1)
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -491,10 +491,13 @@ test('should cache with references', async function (t) {
   await cache.run(1)
 })
 
-test('should handle error throwing in references function (sync)', async function (t) {
+test('should handle references function (sync) throwing an error', async function (t) {
+  t.plan(4)
+
   const cache = new Cache({ ttl: 60, storage: createStorage() })
 
   cache.define('references', {
+    onError: (err) => { t.equal(err.message, 'boom') },
     references: (args, key, result) => { throw new Error('boom') }
   }, () => 'the-result')
 
@@ -502,10 +505,13 @@ test('should handle error throwing in references function (sync)', async functio
   t.equal(await cache.references(1), 'the-result')
 })
 
-test('should handle error throwing in references function (async)', async function (t) {
+test('should handle references function (async) throwing an error', async function (t) {
+  t.plan(4)
+
   const cache = new Cache({ ttl: 60, storage: createStorage() })
 
   cache.define('references', {
+    onError: (err) => { t.equal(err.message, 'boom') },
     references: async (args, key, result) => { throw new Error('boom') }
   }, () => 'the-result')
 


### PR DESCRIPTION
as titled, also (one of) the design cause behind https://github.com/mercurius-js/cache/issues/110