### PR TITLE
fix(cache): clean up dedupes

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -280,12 +280,12 @@ class Wrapper {
     query.promise
       .then(result => {
         // clear the dedupe once done
-        this.dedupes.set(key, undefined)
+        this.dedupes.delete(key)
         return result
       })
       .catch(err => {
         this.onError(err)
-        this.dedupes.set(key, undefined)
+        this.dedupes.delete(key)
         // TODO option to remove key from storage on error?
         // we may want to relay on cache if the original function got error
         // then we probably need more option for that
@@ -298,7 +298,7 @@ class Wrapper {
     // TODO validate value?
     if (value) {
       const key = this.getKey(value)
-      this.dedupes.set(key, undefined)
+      this.dedupes.delete(key)
       await this.storage.remove(this.getStorageKey(key))
       return
     }

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -148,7 +148,7 @@ test('missing function', async (t) => {
 })
 
 test('works with custom serialize', async (t) => {
-  t.plan(2)
+  t.plan(3)
 
   const cache = new Cache({ storage: createStorage() })
 
@@ -165,6 +165,7 @@ test('works with custom serialize', async (t) => {
   const p1 = cache.fetchSomething({ k: 42 })
   const p2 = cache.fetchSomething({ k: 24 })
 
+  t.same([...cache[kValues].fetchSomething.dedupes.keys()], ['42', '24'])
   const res = await Promise.all([p1, p2])
 
   t.same(res, [
@@ -172,7 +173,8 @@ test('works with custom serialize', async (t) => {
     { k: 24 }
   ])
 
-  t.same([...cache[kValues].fetchSomething.dedupes.keys()], ['42', '24'])
+  // Ensure we clean up dedupes
+  t.same([...cache[kValues].fetchSomething.dedupes.keys()], [])
 })
 
 test('constructor - options', async (t) => {


### PR DESCRIPTION
This fixes a memory leak in the cache for dedupes.
We were previously setting the value of each key
to undefined instead of
deleting it. This caused a slow leak
in this package that ultimately begins causing performance issues.
