### PR TITLE
TypeScript definitions added + README explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,36 @@ setInterval(() => {
 
 ---
 
+## TypeScript
+
+This module provides a basic type definition for TypeScript.  
+As the library does some meta-programming and magic stuff behind the scenes, your compiler could yell at you when defining functions using the `define` property.  
+To avoid this, our suggestion is to use a [`Union Type`](https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html) in combination with the given `Cache` type as below:
+
+```ts
+import { createCache } from 'async-cache-dedupe'
+
+const fetchSomething = async (k: any) => {
+  console.log("query", k);
+  return { k };
+};
+
+export type CachedFunctions = {
+  fetchSomething: typeof fetchSomething;
+}; // <--- This is where you define all the functions you want to cache
+
+const cache = createCache({
+  ttl: 5, // seconds
+  storage: { type: 'memory' },
+}) as Cache & CachedFunctions // <--- This is where you tell the compiler to consider both the Cache type and your custom type
+
+cache.define('fetchSomething', fetchSomething)
+
+const p1 = cache.fetchSomething(42) // <--- TypeScript doesn't argue anymore here!
+```
+
+---
+
 ## Maintainers
 
 * [__Matteo Collina__](https://github.com/mcollina), <https://twitter.com/matteocollina>, <https://www.npmjs.com/~matteo.collina>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,78 @@
+type StorageOptionsType = "redis" | "memory";
+
+interface StorageRedisOptions {
+  client: any;
+  log?: any;
+  invalidation?: { referencesTTL: number } | boolean;
+}
+
+interface StorageMemoryOptions {
+  size?: number;
+  log?: any;
+  invalidation?: boolean;
+}
+
+type Events = {
+  onDedupe?: (key: any) => any;
+  onError?: (err: any) => any;
+  onHit?: (key: any) => any;
+  onMiss?: (key: any) => any;
+};
+
+/** StorageInputRedis and StorageInputMemory are a 'necessary evil' instead of function overloading for createCache as typescript seems to ignore a nested overload as this one. */
+type StorageInputRedis = {
+  type: "redis";
+  options?: StorageRedisOptions;
+};
+
+type StorageInputMemory = {
+  type: "memory";
+  options?: StorageMemoryOptions;
+};
+
+declare class StorageInterface {
+  constructor(options: any);
+
+  get(key: string): Promise<undefined | any>;
+  set(
+    key: string,
+    value: any,
+    ttl: number,
+    references?: string[]
+  ): Promise<void>;
+  remove(key: string): Promise<void>;
+  invalidate(references: string[]): Promise<void>;
+  clear(name: string): Promise<void>;
+  refresh(): Promise<void>;
+}
+
+declare function createCache(
+  options?: {
+    storage?: StorageInputRedis | StorageInputMemory;
+    ttl?: number;
+  } & Events
+): Cache;
+
+declare class Cache {
+  constructor(
+    options: {
+      ttl: number;
+      storage: StorageOptionsType;
+    } & Events
+  );
+}
+
+declare function createStorage(
+  type: "redis",
+  options: StorageRedisOptions
+): StorageInterface;
+declare function createStorage(
+  type: "memory",
+  options: StorageMemoryOptions
+): StorageInterface;
+declare function createStorage(
+  type: StorageOptionsType,
+  options: StorageRedisOptions | StorageMemoryOptions
+): StorageInterface;
+
+export { createCache, Cache, createStorage };

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,4 +115,4 @@ declare function createStorage(
   options: StorageRedisOptions | StorageMemoryOptions
 ): StorageInterface;
 
-export { createCache, Cache, createStorage };
+export { createCache, Cache, createStorage, StorageInterface, StorageMemoryOptions };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,49 @@
+// Write a tsd file for the module
+import { expectType } from "tsd";
+import { createCache, Cache, createStorage } from ".";
+import { StorageInterface, StorageMemoryOptions } from "./index.js";
+
+// Testing internal types
+
+const storageOptions: StorageMemoryOptions = {
+  size: 1000,
+};
+
+const cache = createCache();
+expectType<Cache>(cache);
+
+const storage = createStorage("memory", storageOptions);
+expectType<StorageInterface>(storage);
+
+const memoryCache = createCache({
+  storage: {
+    type: "memory",
+    options: storageOptions,
+  },
+});
+expectType<Cache>(memoryCache);
+
+// Testing Union Types
+
+const fetchSomething = async (k: any) => {
+  console.log("query", k);
+  return { k };
+};
+
+export type CachedFunctions = {
+  fetchSomething: typeof fetchSomething;
+};
+
+const unionMemoryCache = createCache({
+  storage: {
+    type: "memory",
+    options: storageOptions,
+  },
+}) as Cache & CachedFunctions;
+expectType<Cache & CachedFunctions>(unionMemoryCache);
+
+unionMemoryCache.define("fetchSomething", fetchSomething);
+expectType<typeof fetchSomething>(unionMemoryCache.fetchSomething);
+
+const result = await unionMemoryCache.fetchSomething("test");
+expectType<{ k: any }>(result);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "standard | snazzy && tap test/*test.js",
+    "test": "standard | snazzy && tap test/*test.js && tsd",
     "lint:fix": "standard --fix",
     "redis": "docker run --rm -p 6379:6379 redis redis-server"
   },
@@ -34,7 +34,8 @@
     "proxyquire": "^2.1.3",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
-    "tap": "^16.3.0"
+    "tap": "^16.3.0",
+    "tsd": "^0.25.0"
   },
   "dependencies": {
     "abstract-logging": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.5.0",
   "description": "An async deduping cache",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "standard | snazzy && tap test/*test.js",
     "lint:fix": "standard --fix",


### PR DESCRIPTION
Hi @mcollina,
as mentioned in #40 , I proceeded with what we stated, bringing in some client-facing types (Didn't bother doing a complete rewrite of course as JSDoc is just enough for the internals and would provide little to no benefit) and explaining the Union Type necessity in the README in a new section created ad-hoc.

I tried bringing in all the examples and some custom code I wrote in a TS file and checked many possible combinations, it seems to be pretty solid.

Happy to see I could achieve almost everything without using `any` but in extreme cases where, in fact, we don't care about given type.  

Of course, tests passed 100%.