### PR TITLE
Fix types of invalidateAll

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,7 +99,7 @@ declare class Cache {
 
   invalidate(name: string, references: References): Promise<void>;
 
-  invalidateAll(name: string, storage: StorageOptionsType): Promise<void>;
+  invalidateAll(references: References, storage?: StorageOptionsType): Promise<void>;
 }
 
 declare function createStorage(

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -47,3 +47,6 @@ expectType<typeof fetchSomething>(unionMemoryCache.fetchSomething);
 
 const result = await unionMemoryCache.fetchSomething("test");
 expectType<{ k: any }>(result);
+
+await unionMemoryCache.invalidateAll("test:*");
+await unionMemoryCache.invalidateAll(["test:1", "test:2", "test:3"], "memory");


### PR DESCRIPTION
- updated typing of invalidateAll function to match implementation

Was using the latest version of this package and noticed the typing issue.