### PR TITLE
Add transformer option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,11 @@ interface StorageMemoryOptions {
   invalidation?: boolean;
 }
 
+interface DataTransformer {
+  serialize: (data: any) => any;
+  deserialize: (data: any) => any;
+}
+
 type Events = {
   onDedupe?: (key: string) => void;
   onError?: (err: any) => void;
@@ -63,6 +68,7 @@ declare function createCache(
   options?: {
     storage?: StorageInputRedis | StorageInputMemory;
     ttl?: number;
+    transformer?: DataTransformer;
   } & Events
 ): Cache;
 
@@ -79,6 +85,7 @@ declare class Cache {
     name: string,
     opts: {
       storage?: StorageOptionsType;
+      transformer?: DataTransformer;
       ttl?: number;
       serialize?: (...args: any[]) => any;
       references?: (...args: any[]) => References | Promise<References>;

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { kValues, kStorage, kStorages, kTTL, kOnDedupe, kOnError, kOnHit, kOnMiss, kStale } = require('./symbol')
+const { kValues, kStorage, kStorages, kTransfromer, kTTL, kOnDedupe, kOnError, kOnHit, kOnMiss, kStale } = require('./symbol')
 const stringify = require('safe-stable-stringify')
 const createStorage = require('./storage')
 
@@ -8,6 +8,7 @@ class Cache {
   /**
    * @param {!Object} opts
    * @param {!Storage} opts.storage - the storage to use
+   * @param {?Object} opts.transformer - the transformer to use
    * @param {?number} [opts.ttl=0] - in seconds; default is 0 seconds, so it only does dedupe without cache
    * @param {?function} opts.onDedupe
    * @param {?function} opts.onError
@@ -51,6 +52,8 @@ class Cache {
     this[kStorages] = new Map()
     this[kStorages].set('_default', options.storage)
 
+    this[kTransfromer] = options.transformer
+
     this[kTTL] = options.ttl || 0
     this[kOnDedupe] = options.onDedupe || noop
     this[kOnError] = options.onError || noop
@@ -64,6 +67,7 @@ class Cache {
    * @param {!string} name name of the function
    * @param {?Object} [opts]
    * @param {?Object} [opts.storage] storage to use; default is the main one
+   * @param {?Object} opts.transformer - the transformer to use
    * @param {?number} [opts.ttl] ttl for the results; default ttl is the one passed to the constructor
    * @param {?function} [opts.onDedupe] function to call on dedupe; default is the one passed to the constructor
    * @param {?function} [opts.onError] function to call on error; default is the one passed to the constructor
@@ -119,8 +123,9 @@ class Cache {
     const onError = opts.onError || this[kOnError]
     const onHit = opts.onHit || this[kOnHit]
     const onMiss = opts.onMiss || this[kOnMiss]
+    const transformer = opts.transformer || this[kTransfromer]
 
-    const wrapper = new Wrapper(func, name, serialize, references, storage, ttl, onDedupe, onError, onHit, onMiss, stale)
+    const wrapper = new Wrapper(func, name, serialize, references, storage, transformer, ttl, onDedupe, onError, onHit, onMiss, stale)
 
     this[kValues][name] = wrapper
     this[name] = wrapper.add.bind(wrapper)
@@ -187,6 +192,7 @@ class Wrapper {
    * @param {function} serialize
    * @param {function} references
    * @param {Storage} storage
+   * @param {Object} transformer
    * @param {number} ttl
    * @param {function} onDedupe
    * @param {function} onError
@@ -194,7 +200,7 @@ class Wrapper {
    * @param {function} onMiss
    * @param {stale} ttl
    */
-  constructor (func, name, serialize, references, storage, ttl, onDedupe, onError, onHit, onMiss, stale) {
+  constructor (func, name, serialize, references, storage, transformer, ttl, onDedupe, onError, onHit, onMiss, stale) {
     this.dedupes = new Map()
     this.func = func
     this.name = name
@@ -202,6 +208,7 @@ class Wrapper {
     this.references = references
 
     this.storage = storage
+    this.transformer = transformer
     this.ttl = ttl
     this.onDedupe = onDedupe
     this.onError = onError
@@ -334,10 +341,16 @@ class Wrapper {
   }
 
   async get (key) {
+    if (this.transformer) {
+      return this.transformer.deserialize(this.storage.get(key))
+    }
     return this.storage.get(key)
   }
 
   async set (key, value, ttl, references) {
+    if (this.transformer) {
+      value = this.transformer.serialize(value)
+    }
     return this.storage.set(key, value, ttl, references)
   }
 

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -3,6 +3,7 @@
 const kValues = Symbol('values')
 const kStorage = Symbol('kStorage')
 const kStorages = Symbol('kStorages')
+const kTransfromer = Symbol('kTransformer')
 const kTTL = Symbol('kTTL')
 const kOnDedupe = Symbol('kOnDedupe')
 const kOnError = Symbol('kOnError')
@@ -10,4 +11,4 @@ const kOnHit = Symbol('kOnHit')
 const kOnMiss = Symbol('kOnMiss')
 const kStale = Symbol('kStale')
 
-module.exports = { kValues, kStorage, kStorages, kTTL, kOnDedupe, kOnError, kOnHit, kOnMiss, kStale }
+module.exports = { kValues, kStorage, kStorages, kTransfromer, kTTL, kOnDedupe, kOnError, kOnHit, kOnMiss, kStale }

--- a/test/transformer.test.js
+++ b/test/transformer.test.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const { test, before, teardown } = require('tap')
+const Redis = require('ioredis')
+
+const createStorage = require('../src/storage')
+const { Cache } = require('../')
+
+let redisClient
+before(async (t) => {
+  redisClient = new Redis()
+})
+
+teardown(async (t) => {
+  await redisClient.quit()
+})
+
+test('should handle a custom transformer to store and get data per cache', async function (t) {
+  t.plan(4)
+
+  const cache = new Cache({
+    storage: createStorage(),
+    transformer: {
+      serialize: (value) => {
+        t.pass('serialize called')
+        return JSON.stringify(value)
+      },
+      deserialize: (value) => {
+        t.pass('deserialize called')
+        return JSON.parse(value)
+      }
+    }
+  })
+
+  cache.define('fetchSomething', async (query, cacheKey) => {
+    return { k: query }
+  })
+
+  t.same(await cache.fetchSomething(42), { k: 42 })
+})
+
+test('should handle a custom transformer to store and get data per define', async function (t) {
+  t.plan(4)
+
+  const cache = new Cache({
+    storage: createStorage()
+  })
+
+  cache.define('fetchSomething', {
+    transformer: {
+      serialize: (value) => {
+        t.pass('serialize called')
+        return JSON.stringify(value)
+      },
+      deserialize: (value) => {
+        t.pass('deserialize called')
+        return JSON.parse(value)
+      }
+    }
+  }, async (query, cacheKey) => {
+    return { k: query }
+  })
+
+  t.same(await cache.fetchSomething(42), { k: 42 })
+})


### PR DESCRIPTION
This implements #46.

This allows passing a transformer library like `superjson` to serialize data types that are not supported by `JSON.stringify`.
The API for this option was inspired by https://trpc.io/docs/data-transformers#using-superjson.

You can use a transformer like this on a per-cache basis:
```javascript
import superjson from "superjson"

const cache = new Cache({
  storage: createStorage(),
  transformer: superjson
})
```

Alternatively, a transformer can be added for a specific function:
```javascript
import superjson from "superjson"

cache.define('fetchSomething', {
  transformer: superjson
}, async (query, cacheKey) => {
  return { k: query }
})
```

I've tried creating tests for this, but the test are failing without any error message. 
Since I'm not too familiar with tap for testing, I was hoping somebody could look into this.

I hope this is helpful!