### PR TITLE
Call setTimeout instead of setImmediate when running in the browser

### DIFF
--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -1,9 +1,12 @@
 'use strict'
 
 const LRUCache = require('mnemonist/lru-cache')
-const { abstractLogging } = require('../util')
+const { abstractLogging, isServerSide } = require('../util')
 const StorageInterface = require('./interface')
 const { findMatchingIndexes, findNotMatching, bsearchIndex, wildcardMatch } = require('../util')
+
+// istanbul ignore next
+const setImmediate = isServerSide ? globalThis.setImmediate : (fn, ...args) => setTimeout(fn, 0, ...args)
 
 const DEFAULT_CACHE_SIZE = 1024
 

--- a/test/browser/fixtures/esbuild.browser-shims.mjs
+++ b/test/browser/fixtures/esbuild.browser-shims.mjs
@@ -1,7 +1,3 @@
 import * as processModule from 'process'
 
 export const process = processModule
-
-export function setImmediate (fn, ...args) {
-  setTimeout(() => fn(...args), 0)
-}

--- a/test/browser/fixtures/rollup.browser.config.mjs
+++ b/test/browser/fixtures/rollup.browser.config.mjs
@@ -8,7 +8,6 @@ export default {
   input: ['test/browser/test-browser.js'],
   external: ['./src/storage/redis.js'],
   output: {
-    intro: 'function setImmediate(fn, ...args) { setTimeout(() => fn(...args), 0) }',
     file: 'tmp/rollup/suite.browser.js',
     format: 'iife',
     name: 'asyncDedupeStorageTestSuite'

--- a/test/browser/fixtures/vite.browser.config.mjs
+++ b/test/browser/fixtures/vite.browser.config.mjs
@@ -16,9 +16,6 @@ export default defineConfig({
       formats: ['iife']
     },
     rollupOptions: {
-      output: {
-        intro: 'function setImmediate(fn, ...args) { setTimeout(() => fn(...args), 0) }'
-      },
       external: ['./src/storage/redis.js']
     },
     emptyOutDir: false,

--- a/test/browser/fixtures/webpack.browser.config.mjs
+++ b/test/browser/fixtures/webpack.browser.config.mjs
@@ -17,10 +17,6 @@ export default {
   target: 'web',
   performance: false,
   plugins: [
-    new webpack.BannerPlugin({
-      banner: 'function setImmediate(fn, ...args) { setTimeout(() => fn(...args), 0) }',
-      raw: true
-    }),
     new webpack.ProvidePlugin({
       process: require.resolve('process')
     })


### PR DESCRIPTION
setImmediate isn't implemented in any modern browser, so this updates the memory storage engine to call `setTimeout` instead when running in the browser. Behavior under Node is unchanged.

Note that this uses `globalThis`, which is only supported in Node 12+.

Resolves #55
