### PR TITLE
Allow define.ttl to be a number or function in the typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,17 +82,17 @@ declare class Cache {
   );
 
 
-  define(
+  define<T extends (...args: any[]) => any>(
     name: string,
     opts: {
       storage?: StorageOptionsType;
       transformer?: DataTransformer;
-      ttl?: number;
+      ttl?: number | ((result: Awaited<ReturnType<T>>) => number);
       stale?: number;
       serialize?: (...args: any[]) => any;
       references?: (...args: any[]) => References | Promise<References>;
     } & Events,
-    func?: (...args: any[]) => any
+    func?: T
   ): void;
   define(
     name: string,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -39,6 +39,7 @@ const fetchSomething = async (k: any) => {
 export type CachedFunctions = {
   fetchSomething: typeof fetchSomething;
   fetchSomethingElse: typeof fetchSomething;
+  fetchSomethingElseWithTtlFunction: typeof fetchSomething;
 };
 
 const unionMemoryCache = createCache({
@@ -54,6 +55,10 @@ expectType<typeof fetchSomething>(unionMemoryCache.fetchSomething);
 
 unionMemoryCache.define("fetchSomethingElse", { ttl: 1000, stale: 1000}, fetchSomething);
 expectType<typeof fetchSomething>(unionMemoryCache.fetchSomethingElse);
+
+unionMemoryCache.define("fetchSomethingElseWithTtlFunction", { ttl: (result) => result.k ? 1000 : 5, stale: 1000}, fetchSomething);
+expectType<typeof fetchSomething>(unionMemoryCache.fetchSomethingElseWithTtlFunction);
+
 
 const result = await unionMemoryCache.fetchSomething("test");
 expectType<{ k: any }>(result);


### PR DESCRIPTION
The type definitions only allow a number for `ttl` in define options. This should fix this problem.

I am not sure about the best way to test this issue. It definitely gives an error if the types mismatch.