### PR TITLE
feat: support dynamic stale config property

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Creates a new cache.
 Options:
 
 * `ttl`: the maximum time a cache entry can live, default `0`; if `0`, an element is removed from the cache as soon as the promise resolves.
-* `stale`: the time after which the value is served from the cache after the ttl has expired. This can be a number in seconds or a function that accepts the data and returns a the cache value.
+* `stale`: the time after which the value is served from the cache after the ttl has expired. This can be a number in seconds or a function that accepts the data and returns the stale value.
 * `onDedupe`: a function that is called every time it is defined is deduped.
 * `onError`: a function that is called every time there is a cache error.
 * `onHit`: a function that is called every time there is a hit in the cache.
@@ -114,7 +114,7 @@ in the cache. The cache key for `arg` is computed using [`safe-stable-stringify`
 Options:
 
 * `ttl`: a number or a function that returns a number of the maximum time a cache entry can live, default as defined in the cache; default is zero, so cache is disabled, the function will be only the deduped. The first argument of the function is the result of the original function.
-* `stale`: the time after which the value is served from the cache after the ttl has expired. This can be a number in seconds or a function that accepts the data and returns a the cache value.
+* `stale`: the time after which the value is served from the cache after the ttl has expired. This can be a number in seconds or a function that accepts the data and returns the stale value.
 * `serialize`: a function to convert the given argument into a serializable object (or string).
 * `onDedupe`: a function that is called every time there is defined is deduped.
 * `onError`: a function that is called every time there is a cache error.
@@ -163,12 +163,12 @@ Options:
 
   cache.define('fetchUserProfile', {
     ttl: 60,
-    state: (result) => result.staleWhilteRevalidateInSeconds
+    state: (result) => result.staleWhileRevalidateInSeconds
   }, async () => {
     
     const response = await fetch("https://example.com/token");
     const result = await response.json();
-    // => { "username": "MrTest", "staleWhilteRevalidateInSeconds": 5 }
+    // => { "username": "MrTest", "staleWhileRevalidateInSeconds": 5 }
     
     return result;
   })

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ import { createCache } from 'async-cache-dedupe'
 
 const cache = createCache({
   ttl: 5, // seconds
+  stale: 5, // number of seconds to return data after ttl has expired
   storage: { type: 'memory' },
 })
 
@@ -52,7 +53,7 @@ Creates a new cache.
 Options:
 
 * `ttl`: the maximum time a cache entry can live, default `0`; if `0`, an element is removed from the cache as soon as the promise resolves.
-* `stale`: the time after which the value is served from the cache after the ttl has expired.
+* `stale`: the time after which the value is served from the cache after the ttl has expired. This can be a number in seconds or a function that accepts the data and returns a the cache value.
 * `onDedupe`: a function that is called every time it is defined is deduped.
 * `onError`: a function that is called every time there is a cache error.
 * `onHit`: a function that is called every time there is a hit in the cache.
@@ -113,7 +114,7 @@ in the cache. The cache key for `arg` is computed using [`safe-stable-stringify`
 Options:
 
 * `ttl`: a number or a function that returns a number of the maximum time a cache entry can live, default as defined in the cache; default is zero, so cache is disabled, the function will be only the deduped. The first argument of the function is the result of the original function.
-* `stale`: the time after which the value is served from the cache after the ttl has expired.
+* `stale`: the time after which the value is served from the cache after the ttl has expired. This can be a number in seconds or a function that accepts the data and returns a the cache value.
 * `serialize`: a function to convert the given argument into a serializable object (or string).
 * `onDedupe`: a function that is called every time there is defined is deduped.
 * `onError`: a function that is called every time there is a cache error.
@@ -148,6 +149,26 @@ Options:
     const response = await fetch("https://example.com/token");
     const result = await response.json();
     // => { "token": "abc", "expiresInSeconds": 60 }
+    
+    return result;
+  })
+
+  await cache.fetchAccessToken()
+  ```
+
+  Example 3 - dynamically set `stale` value based on result.
+
+  ```js
+  const cache = createCache()
+
+  cache.define('fetchUserProfile', {
+    ttl: 60,
+    state: (result) => result.staleWhilteRevalidateInSeconds
+  }, async () => {
+    
+    const response = await fetch("https://example.com/token");
+    const result = await response.json();
+    // => { "username": "MrTest", "staleWhilteRevalidateInSeconds": 5 }
     
     return result;
   })

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,16 +62,16 @@ declare class StorageInterface {
 declare function createCache(
 	options?: {
 		storage?: StorageInputRedis | StorageInputMemory;
-		ttl?: number;
+		ttl?: number | ((result: unknown) => number);
 		transformer?: DataTransformer;
-		stale?: number;
+		stale?: number | ((result: unknown) => number);
 	} & Events,
 ): Cache;
 
 declare class Cache {
   constructor(
     options: {
-      ttl: number;
+      ttl: number | ((result: unknown) => number);
       storage: StorageOptionsType;
     } & Events
   );
@@ -83,7 +83,7 @@ declare class Cache {
       storage?: StorageOptionsType;
       transformer?: DataTransformer;
       ttl?: number | ((result: Awaited<ReturnType<T>>) => number);
-      stale?: number;
+      stale?: number | ((result: Awaited<ReturnType<T>>) => number);
       serialize?: (...args: any[]) => any;
       references?: (
 				args: Parameters<T>,

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -84,3 +84,66 @@ test('stale as parameter', async (t) => {
 
   t.same(await cache.fetchSomething(42), { k: 42 })
 })
+
+test('stale as a function', async (t) => {
+  t.plan(11)
+
+  const storage = createStorage()
+
+  const cache = new Cache({
+    storage,
+    ttl: 1,
+    stale: (result) => result.stale
+  })
+
+  let toReturn = 42
+
+  cache.define('fetchSomething', async (query) => {
+    t.equal(query, 42)
+    return { k: toReturn, stale: 9 }
+  })
+
+  t.same(await cache.fetchSomething(42), { k: 42, stale: 9 })
+  t.same(await cache.fetchSomething(42), { k: 42, stale: 9 })
+
+  t.equal(storage.getTTL('fetchSomething~42'), 10)
+  await sleep(2500)
+  t.equal(storage.getTTL('fetchSomething~42') < 10, true)
+
+  // This value will be revalidated
+  toReturn++
+  t.same(await cache.fetchSomething(42), { k: 42, stale: 9 })
+  t.equal(storage.getTTL('fetchSomething~42'), 10)
+
+  await sleep(500)
+
+  t.same(await cache.fetchSomething(42), { k: 43, stale: 9 })
+
+  t.same(await cache.fetchSomething(42), { k: 43, stale: 9 })
+  t.equal(storage.getTTL('fetchSomething~42'), 10)
+})
+
+test('stale as a function parameter', async (t) => {
+  t.plan(6)
+
+  const cache = new Cache({
+    storage: createStorage(),
+    ttl: 1
+  })
+
+  cache.define('fetchSomething', { stale: () => 9 }, async (query) => {
+    t.equal(query, 42)
+    return { k: query }
+  })
+
+  t.same(await cache.fetchSomething(42), { k: 42 })
+  t.same(await cache.fetchSomething(42), { k: 42 })
+
+  await sleep(2500)
+
+  t.same(await cache.fetchSomething(42), { k: 42 })
+
+  await sleep(500)
+
+  t.same(await cache.fetchSomething(42), { k: 42 })
+})


### PR DESCRIPTION
Adds support for a dynamic stale value via a function in the options. Also includes a small fix for the "global" ttl typings to allow a function as it is supported in code

#69 