### PR TITLE
fix types: define func expected to have only one argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,7 @@ declare class Cache {
     } & Events
   );
 
-  define<T extends (...args: any[]) => any, N extends string, S extends this>(
+  define<T extends (args: any) => any, N extends string, S extends this>(
     name: N,
     opts: {
       storage?: StorageOptionsType;
@@ -85,14 +85,14 @@ declare class Cache {
       stale?: number | ((result: Awaited<ReturnType<T>>) => number);
       serialize?: (...args: any[]) => any;
       references?: (
-        args: Parameters<T>,
+        args: Parameters<T>[0],
         key: string,
         result: Awaited<ReturnType<T>>
       ) => References | Promise<References>;
     } & Events,
     func?: T
   ): S & { [n in N]: T };
-  define<T extends (...args: any[]) => any, N extends string, S extends this>(
+  define<T extends (args: any[]) => any, N extends string, S extends this>(
     name: N,
     opts: T
   ): S & { [n in N]: T };


### PR DESCRIPTION
Hi @mcollina, thanks for the amazing library. I noticed I was wrong results and weird cache keys and noticed I was using the library wrong since TypeScript types are incorrect.

Looking at the source code, it seems like `func` is expected to have a single argument called `args`. However, TS types are defined as if it is supporting multiple arguments and `references` option is getting an array of `func` parameters. Therefore, only the first argument is actually called and used in key calculations.

Here is my code for your reference:

```ts
@Injectable()
export class OrganizationMemberService {
  private readonly logger: Logger;
  private readonly cache;

  constructor(
    private prisma: PrismaService,
    @InjectRedis() private readonly redis: Redis,
  ) {
    this.logger = new Logger(OrganizationMemberService.name);
    this.cache = createCache({
      ttl: 60 * 60 * 24,
      storage: {
        type: 'redis',
        options: {
          client: redis,
          invalidation: { referencesTTL: 60 * 60 * 24 },
        },
      },
    }).define(
      'fetchOrganizationMember',
      {
        references: (args) => {
          this.logger.log(`references args: %o`, args);
          return [`organization-member~${args[0]}:${args[1]}`];
        },
      },
      async (
        organizationId: string,
        memberId: string,
      ): Promise<OrganizationMemberDto | null> => {
        const organizationMember =
          await this.prisma.organizationMember.findUnique({
            where: {
              organizationId_userId: {
                organizationId,
                userId: memberId,
              },
            },
          });

        this.logger.log(
          'Fetched organization member for organizationId: %s, memberId: %s: %o',
          organizationId,
          memberId,
          organizationMember,
        );

        return organizationMember
          ? new OrganizationMemberDto(organizationMember)
          : null;
      },
    );
  }

  async getOrganizationMember(
    organizationId: string,
    memberId: string,
  ): Promise<OrganizationMemberDto | null> {
    const organizationMember = await this.cache.fetchOrganizationMember(
      organizationId,
      memberId,
    );

    if (!organizationMember) {
      this.logger.log(
        'Organization member not found for organizationId: %s, memberId: %s',
        organizationId,
        memberId,
      );
    }

    return organizationMember;
  }
}

```
![image](https://github.com/mcollina/async-cache-dedupe/assets/26417668/f4900cc2-2c11-44a7-a33f-eb05cfbbdac3)
