### PR TITLE
fix: support invalidation on redis invalid references

### DIFF
--- a/src/storage/redis.js
+++ b/src/storage/redis.js
@@ -214,6 +214,7 @@ class StorageRedis extends StorageInterface {
     const removed = []
     for (let i = 0; i < keys.length; i++) {
       const key0 = keys[i][1]
+      if (!key0) { continue }
       this.log.debug({ msg: 'acd/storage/redis._invalidateReferences got keys to be invalidated', keys: key0 })
       for (let j = 0; j < key0.length; j++) {
         const key1 = key0[j]

--- a/test/storage-redis.test.js
+++ b/test/storage-redis.test.js
@@ -561,6 +561,13 @@ test('storage redis', async (t) => {
 
       t.doesNotThrow(() => storage.invalidate(['pizzers']))
     })
+
+    test('should not throw invalidating non-existing references', async (t) => {
+      const storage = createStorage('redis', { client: redisClient, invalidation: true })
+      await redisClient.set('r:model:1', 'value')
+
+      t.doesNotThrow(() => storage.invalidate(['model:1', 'model:2']))
+    })
   })
 
   test('clear', async (t) => {


### PR DESCRIPTION
closes https://github.com/mcollina/async-cache-dedupe/issues/89