### PR TITLE
refactor(tests): migrate from tap to node test runners

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "license": "MIT",
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
+    "@matteo.collina/tspl": "^0.1.0",
     "@rollup/plugin-commonjs": "^25.0.4",
     "@rollup/plugin-inject": "^5.0.3",
     "@rollup/plugin-node-resolve": "^15.2.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "standard | snazzy && tap test/*test.js && tsd",
+    "test": "standard | snazzy && node --test test/*.js && tsd",
     "test:browser": "node test/browser/helpers/runner-browser.mjs",
     "lint:fix": "standard --fix",
     "redis": "docker run --rm -p 6379:6379 redis redis-server"
@@ -50,7 +50,6 @@
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",
     "stream-browserify": "^3.0.0",
-    "tap": "^18.4",
     "tap-mocha-reporter": "^5.0.4",
     "tap-parser": "^15.2.0",
     "tape": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "standard | snazzy && node --test test/*.js && tsd",
+    "test": "standard | snazzy && c8 --100 node --test test/*.js && tsd",
     "test:browser": "node test/browser/helpers/runner-browser.mjs",
     "lint:fix": "standard --fix",
     "redis": "docker run --rm -p 6379:6379 redis redis-server"
@@ -37,6 +37,7 @@
     "@rollup/plugin-node-resolve": "^15.2.1",
     "browserify": "^17.0.0",
     "buffer": "^6.0.3",
+    "c8": "^8.0.1",
     "esbuild": "^0.19.4",
     "esbuild-plugin-alias": "^0.2.1",
     "events": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "standard | snazzy && c8 --100 node --test test/*.js && tsd",
+    "test": "standard | snazzy && c8 --100 node --test test/*test.js && tsd",
     "test:browser": "node test/browser/helpers/runner-browser.mjs",
     "lint:fix": "standard --fix",
     "redis": "docker run --rm -p 6379:6379 redis redis-server"

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { describe, test, before, after } = require('node:test')
+const { describe, test, beforeEach, afterEach } = require('node:test')
 const assert = require('node:assert')
 const { tspl } = require('@matteo.collina/tspl')
 const Redis = require('ioredis')
@@ -20,11 +20,11 @@ const dummyStorage = {
 }
 
 let redisClient
-before(async (t) => {
+beforeEach(async () => {
   redisClient = new Redis()
 })
 
-after(async (t) => {
+afterEach(async () => {
   await redisClient.quit()
 })
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { describe, test, beforeEach, afterEach } = require('node:test')
+const { describe, test, before, after } = require('node:test')
 const assert = require('node:assert')
 const { tspl } = require('@matteo.collina/tspl')
 const Redis = require('ioredis')
@@ -20,610 +20,613 @@ const dummyStorage = {
 }
 
 let redisClient
-beforeEach(async () => {
-  redisClient = new Redis()
-})
 
-afterEach(async () => {
-  await redisClient.quit()
-})
-
-test('create a Cache that dedupes', async (t) => {
-  const { deepStrictEqual, equal } = tspl(t, { plan: 6 })
-
-  let dedupes = 0
-  const cache = new Cache({
-    storage: dummyStorage,
-    onDedupe () {
-      dedupes++
-    }
+describe('base', async () => {
+  before(async () => {
+    redisClient = new Redis()
   })
 
-  const expected = [42, 24]
-
-  cache.define('fetchSomething', async (value, key) => {
-    equal(value, expected.shift())
-    equal(stringify(value), key)
-    return { k: value }
+  after(async () => {
+    await redisClient.quit()
   })
 
-  const p1 = cache.fetchSomething(42)
-  const p2 = cache.fetchSomething(24)
-  const p3 = cache.fetchSomething(42)
+  test('create a Cache that dedupes', async (t) => {
+    const { deepStrictEqual, equal } = tspl(t, { plan: 6 })
 
-  const res = await Promise.all([p1, p2, p3])
-
-  deepStrictEqual(res, [
-    { k: 42 },
-    { k: 24 },
-    { k: 42 }
-  ])
-  equal(dedupes, 1)
-})
-
-test('create a Cache that dedupes full signature', async (t) => {
-  const { deepStrictEqual, equal } = tspl(t, { plan: 3 })
-
-  const cache = new Cache({ storage: dummyStorage })
-
-  const expected = [42, 24]
-
-  cache.define('fetchSomething', undefined, async (query) => {
-    equal(query, expected.shift())
-    return { k: query }
-  })
-
-  const p1 = cache.fetchSomething(42)
-  const p2 = cache.fetchSomething(24)
-  const p3 = cache.fetchSomething(42)
-
-  const res = await Promise.all([p1, p2, p3])
-
-  deepStrictEqual(res, [
-    { k: 42 },
-    { k: 24 },
-    { k: 42 }
-  ])
-})
-
-test('create a cache with the factory function, default options', async t => {
-  const cache = createCache()
-
-  assert.ok(cache[kStorage])
-
-  cache.define('plusOne', async (value, key) => value + 1)
-
-  assert.equal(await cache.plusOne(42), 43)
-  assert.equal(await cache.plusOne(24), 25)
-  assert.equal(await cache.plusOne(42), 43)
-})
-
-test('create a cache with the factory function, with default storage', async t => {
-  let hits = 0
-  const cache = createCache({
-    ttl: 1,
-    onHit () { hits++ }
-  })
-
-  assert.ok(cache[kStorage].get)
-  assert.ok(cache[kStorage].set)
-
-  cache.define('plusOne', async (value, key) => value + 1)
-
-  assert.equal(await cache.plusOne(42), 43)
-  assert.equal(await cache.plusOne(24), 25)
-  assert.equal(await cache.plusOne(42), 43)
-
-  assert.equal(hits, 1)
-})
-
-test('create a cache with the factory function, with storage', async t => {
-  let hits = 0
-  const cache = createCache({
-    ttl: 1,
-    storage: { type: 'memory', options: { size: 9 } },
-    onHit () { hits++ }
-  })
-
-  assert.equal(cache[kStorage].size, 9)
-
-  cache.define('plusOne', async (value, key) => value + 1)
-
-  assert.equal(await cache.plusOne(42), 43)
-  assert.equal(await cache.plusOne(24), 25)
-  assert.equal(await cache.plusOne(42), 43)
-
-  assert.equal(hits, 1)
-})
-
-test('missing function', async (t) => {
-  const cache = new Cache({ storage: createStorage() })
-  assert.throws(function () {
-    cache.define('something', null)
-  })
-  assert.throws(function () {
-    cache.define('something', 42)
-  })
-  assert.throws(function () {
-    cache.define('something', 'a string')
-  })
-})
-
-test('works with custom serialize', async (t) => {
-  const { deepStrictEqual } = tspl(t, { plan: 3 })
-
-  const cache = new Cache({ storage: createStorage() })
-
-  cache.define(
-    'fetchSomething',
-    {
-      serialize (args) { return args.k }
-    },
-    async (queries) => {
-      return queries
-    }
-  )
-
-  const p1 = cache.fetchSomething({ k: 42 })
-  const p2 = cache.fetchSomething({ k: 24 })
-
-  deepStrictEqual([...cache[kValues].fetchSomething.dedupes.keys()], ['42', '24'])
-  const res = await Promise.all([p1, p2])
-
-  deepStrictEqual(res, [
-    { k: 42 },
-    { k: 24 }
-  ])
-
-  // Ensure we clean up dedupes
-  deepStrictEqual([...cache[kValues].fetchSomething.dedupes.keys()], [])
-})
-
-describe('constructor - options', async () => {
-  test('missing storage', async () => {
-    assert.throws(function () {
-      // eslint-disable-next-line no-new
-      new Cache()
+    let dedupes = 0
+    const cache = new Cache({
+      storage: dummyStorage,
+      onDedupe () {
+        dedupes++
+      }
     })
-  })
 
-  test('invalid ttl', async () => {
-    assert.throws(function () {
-      // eslint-disable-next-line no-new
-      new Cache({ storage: createStorage(), ttl: -1 })
+    const expected = [42, 24]
+
+    cache.define('fetchSomething', async (value, key) => {
+      equal(value, expected.shift())
+      equal(stringify(value), key)
+      return { k: value }
     })
+
+    const p1 = cache.fetchSomething(42)
+    const p2 = cache.fetchSomething(24)
+    const p3 = cache.fetchSomething(42)
+
+    const res = await Promise.all([p1, p2, p3])
+
+    deepStrictEqual(res, [
+      { k: 42 },
+      { k: 24 },
+      { k: 42 }
+    ])
+    equal(dedupes, 1)
   })
 
-  test('invalid onDedupe', async () => {
-    assert.throws(function () {
-      // eslint-disable-next-line no-new
-      new Cache({ storage: createStorage(), onDedupe: -1 })
+  test('create a Cache that dedupes full signature', async (t) => {
+    const { deepStrictEqual, equal } = tspl(t, { plan: 3 })
+
+    const cache = new Cache({ storage: dummyStorage })
+
+    const expected = [42, 24]
+
+    cache.define('fetchSomething', undefined, async (query) => {
+      equal(query, expected.shift())
+      return { k: query }
     })
+
+    const p1 = cache.fetchSomething(42)
+    const p2 = cache.fetchSomething(24)
+    const p3 = cache.fetchSomething(42)
+
+    const res = await Promise.all([p1, p2, p3])
+
+    deepStrictEqual(res, [
+      { k: 42 },
+      { k: 24 },
+      { k: 42 }
+    ])
   })
 
-  test('invalid onError', async () => {
-    assert.throws(function () {
-      // eslint-disable-next-line no-new
-      new Cache({ storage: createStorage(), onError: {} })
+  test('create a cache with the factory function, default options', async t => {
+    const cache = createCache()
+
+    assert.ok(cache[kStorage])
+
+    cache.define('plusOne', async (value, key) => value + 1)
+
+    assert.equal(await cache.plusOne(42), 43)
+    assert.equal(await cache.plusOne(24), 25)
+    assert.equal(await cache.plusOne(42), 43)
+  })
+
+  test('create a cache with the factory function, with default storage', async t => {
+    let hits = 0
+    const cache = createCache({
+      ttl: 1,
+      onHit () { hits++ }
     })
+
+    assert.ok(cache[kStorage].get)
+    assert.ok(cache[kStorage].set)
+
+    cache.define('plusOne', async (value, key) => value + 1)
+
+    assert.equal(await cache.plusOne(42), 43)
+    assert.equal(await cache.plusOne(24), 25)
+    assert.equal(await cache.plusOne(42), 43)
+
+    assert.equal(hits, 1)
   })
 
-  test('invalid onHit', async () => {
-    assert.throws(function () {
-      // eslint-disable-next-line no-new
-      new Cache({ storage: createStorage(), onHit: -1 })
+  test('create a cache with the factory function, with storage', async t => {
+    let hits = 0
+    const cache = createCache({
+      ttl: 1,
+      storage: { type: 'memory', options: { size: 9 } },
+      onHit () { hits++ }
     })
+
+    assert.equal(cache[kStorage].size, 9)
+
+    cache.define('plusOne', async (value, key) => value + 1)
+
+    assert.equal(await cache.plusOne(42), 43)
+    assert.equal(await cache.plusOne(24), 25)
+    assert.equal(await cache.plusOne(42), 43)
+
+    assert.equal(hits, 1)
   })
 
-  test('invalid onMiss', async () => {
-    assert.throws(function () {
-      // eslint-disable-next-line no-new
-      new Cache({ storage: createStorage(), onMiss: -1 })
-    })
-  })
-})
-
-describe('define - options', async () => {
-  test('wrong serialize', async () => {
+  test('missing function', async (t) => {
     const cache = new Cache({ storage: createStorage() })
     assert.throws(function () {
-      cache.define('something', {
-        serialize: 42
-      }, async () => { })
+      cache.define('something', null)
     })
-  })
-
-  test('wrong references', async () => {
-    const cache = new Cache({ storage: createStorage() })
     assert.throws(function () {
-      cache.define('something', {
-        references: 42
-      }, async () => { })
+      cache.define('something', 42)
+    })
+    assert.throws(function () {
+      cache.define('something', 'a string')
     })
   })
 
-  test('custom storage', async () => {
+  test('works with custom serialize', async (t) => {
+    const { deepStrictEqual } = tspl(t, { plan: 3 })
+
     const cache = new Cache({ storage: createStorage() })
-    cache.define('foo', {
-      storage: { type: 'memory', options: { size: 9 } }
-    }, () => true)
 
-    assert.ok(cache.foo())
-  })
-})
+    cache.define(
+      'fetchSomething',
+      {
+        serialize (args) { return args.k }
+      },
+      async (queries) => {
+        return queries
+      }
+    )
 
-test('safe stable serialize', async (t) => {
-  const { deepStrictEqual, equal } = tspl(t, { plan: 5 })
+    const p1 = cache.fetchSomething({ k: 42 })
+    const p2 = cache.fetchSomething({ k: 24 })
 
-  const cache = new Cache({ storage: createStorage() })
+    deepStrictEqual([...cache[kValues].fetchSomething.dedupes.keys()], ['42', '24'])
+    const res = await Promise.all([p1, p2])
 
-  const expected = [
-    { foo: 'bar', bar: 'foo' },
-    { hello: 'world' }
-  ]
+    deepStrictEqual(res, [
+      { k: 42 },
+      { k: 24 }
+    ])
 
-  cache.define('fetchSomething', async (query, cacheKey) => {
-    deepStrictEqual(query, expected.shift())
-    equal(stringify(query), cacheKey)
-
-    return { k: query }
-  })
-
-  const p1 = cache.fetchSomething({ foo: 'bar', bar: 'foo' })
-  const p2 = cache.fetchSomething({ hello: 'world' })
-  const p3 = cache.fetchSomething({ bar: 'foo', foo: 'bar' })
-
-  const res = await Promise.all([p1, p2, p3])
-
-  deepStrictEqual(res, [
-    { k: { foo: 'bar', bar: 'foo' } },
-    { k: { hello: 'world' } },
-    { k: { foo: 'bar', bar: 'foo' } }
-  ])
-})
-
-test('strings', async (t) => {
-  const { deepStrictEqual, equal } = tspl(t, { plan: 3 })
-
-  const cache = new Cache({ storage: createStorage() })
-
-  const expected = ['42', '24']
-
-  cache.define('fetchSomething', async (query) => {
-    equal(query, expected.shift())
-    return { k: query }
+    // Ensure we clean up dedupes
+    deepStrictEqual([...cache[kValues].fetchSomething.dedupes.keys()], [])
   })
 
-  const p1 = cache.fetchSomething('42')
-  const p2 = cache.fetchSomething('24')
-  const p3 = cache.fetchSomething('42')
+  describe('constructor - options', async () => {
+    test('missing storage', async () => {
+      assert.throws(function () {
+        // eslint-disable-next-line no-new
+        new Cache()
+      })
+    })
 
-  const res = await Promise.all([p1, p2, p3])
+    test('invalid ttl', async () => {
+      assert.throws(function () {
+        // eslint-disable-next-line no-new
+        new Cache({ storage: createStorage(), ttl: -1 })
+      })
+    })
 
-  deepStrictEqual(res, [
-    { k: '42' },
-    { k: '24' },
-    { k: '42' }
-  ])
-})
+    test('invalid onDedupe', async () => {
+      assert.throws(function () {
+        // eslint-disable-next-line no-new
+        new Cache({ storage: createStorage(), onDedupe: -1 })
+      })
+    })
 
-test('do not cache failures', async (t) => {
-  const { deepStrictEqual, ok, rejects } = tspl(t, { plan: 4 })
+    test('invalid onError', async () => {
+      assert.throws(function () {
+        // eslint-disable-next-line no-new
+        new Cache({ storage: createStorage(), onError: {} })
+      })
+    })
 
-  const cache = new Cache({ storage: createStorage() })
+    test('invalid onHit', async () => {
+      assert.throws(function () {
+        // eslint-disable-next-line no-new
+        new Cache({ storage: createStorage(), onHit: -1 })
+      })
+    })
 
-  let called = false
-  cache.define('fetchSomething', async (query) => {
-    ok('called')
-    if (!called) {
-      called = true
+    test('invalid onMiss', async () => {
+      assert.throws(function () {
+        // eslint-disable-next-line no-new
+        new Cache({ storage: createStorage(), onMiss: -1 })
+      })
+    })
+  })
+
+  describe('define - options', async () => {
+    test('wrong serialize', async () => {
+      const cache = new Cache({ storage: createStorage() })
+      assert.throws(function () {
+        cache.define('something', {
+          serialize: 42
+        }, async () => { })
+      })
+    })
+
+    test('wrong references', async () => {
+      const cache = new Cache({ storage: createStorage() })
+      assert.throws(function () {
+        cache.define('something', {
+          references: 42
+        }, async () => { })
+      })
+    })
+
+    test('custom storage', async () => {
+      const cache = new Cache({ storage: createStorage() })
+      cache.define('foo', {
+        storage: { type: 'memory', options: { size: 9 } }
+      }, () => true)
+
+      assert.ok(cache.foo())
+    })
+  })
+
+  test('safe stable serialize', async (t) => {
+    const { deepStrictEqual, equal } = tspl(t, { plan: 5 })
+
+    const cache = new Cache({ storage: createStorage() })
+
+    const expected = [
+      { foo: 'bar', bar: 'foo' },
+      { hello: 'world' }
+    ]
+
+    cache.define('fetchSomething', async (query, cacheKey) => {
+      deepStrictEqual(query, expected.shift())
+      equal(stringify(query), cacheKey)
+
+      return { k: query }
+    })
+
+    const p1 = cache.fetchSomething({ foo: 'bar', bar: 'foo' })
+    const p2 = cache.fetchSomething({ hello: 'world' })
+    const p3 = cache.fetchSomething({ bar: 'foo', foo: 'bar' })
+
+    const res = await Promise.all([p1, p2, p3])
+
+    deepStrictEqual(res, [
+      { k: { foo: 'bar', bar: 'foo' } },
+      { k: { hello: 'world' } },
+      { k: { foo: 'bar', bar: 'foo' } }
+    ])
+  })
+
+  test('strings', async (t) => {
+    const { deepStrictEqual, equal } = tspl(t, { plan: 3 })
+
+    const cache = new Cache({ storage: createStorage() })
+
+    const expected = ['42', '24']
+
+    cache.define('fetchSomething', async (query) => {
+      equal(query, expected.shift())
+      return { k: query }
+    })
+
+    const p1 = cache.fetchSomething('42')
+    const p2 = cache.fetchSomething('24')
+    const p3 = cache.fetchSomething('42')
+
+    const res = await Promise.all([p1, p2, p3])
+
+    deepStrictEqual(res, [
+      { k: '42' },
+      { k: '24' },
+      { k: '42' }
+    ])
+  })
+
+  test('do not cache failures', async (t) => {
+    const { deepStrictEqual, ok, rejects } = tspl(t, { plan: 4 })
+
+    const cache = new Cache({ storage: createStorage() })
+
+    let called = false
+    cache.define('fetchSomething', async (query) => {
+      ok('called')
+      if (!called) {
+        called = true
+        throw new Error('kaboom')
+      }
+      return { k: query }
+    })
+
+    await rejects(cache.fetchSomething(42))
+    deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  })
+
+  test('do not cache failures async', async (t) => {
+    const { ok, rejects, deepStrictEqual } = tspl(t, { plan: 5 })
+
+    const storage = createStorage()
+    storage.remove = async () => {
+      ok('async remove called')
       throw new Error('kaboom')
     }
-    return { k: query }
-  })
+    const cache = new Cache({ storage })
 
-  await rejects(cache.fetchSomething(42))
-  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
-})
-
-test('do not cache failures async', async (t) => {
-  const { ok, rejects, deepStrictEqual } = tspl(t, { plan: 5 })
-
-  const storage = createStorage()
-  storage.remove = async () => {
-    ok('async remove called')
-    throw new Error('kaboom')
-  }
-  const cache = new Cache({ storage })
-
-  let called = false
-  cache.define('fetchSomething', async (query) => {
-    ok('called')
-    if (!called) {
-      called = true
-      throw new Error('kaboom')
-    }
-    return { k: query }
-  })
-
-  await rejects(cache.fetchSomething(42))
-  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
-})
-
-test('clear the full cache', async (t) => {
-  const { ok, deepStrictEqual } = tspl(t, { plan: 7 })
-
-  const cache = new Cache({ ttl: 1, storage: createStorage() })
-
-  cache.define('fetchA', async (query) => {
-    ok('a called')
-    return { k: query }
-  })
-
-  cache.define('fetchB', async (query) => {
-    ok('b called')
-    return { j: query }
-  })
-
-  deepStrictEqual(await Promise.all([
-    cache.fetchA(42),
-    cache.fetchB(24)
-  ]), [
-    { k: 42 },
-    { j: 24 }
-  ])
-
-  deepStrictEqual(await Promise.all([
-    cache.fetchA(42),
-    cache.fetchB(24)
-  ]), [
-    { k: 42 },
-    { j: 24 }
-  ])
-
-  await cache.clear()
-
-  deepStrictEqual(await Promise.all([
-    cache.fetchA(42),
-    cache.fetchB(24)
-  ]), [
-    { k: 42 },
-    { j: 24 }
-  ])
-})
-
-test('clears only one method', async (t) => {
-  const { ok, deepStrictEqual } = tspl(t, { plan: 6 })
-
-  const cache = new Cache({ ttl: 1, storage: createStorage() })
-
-  cache.define('fetchA', async (query) => {
-    ok('a called')
-    return { k: query }
-  })
-
-  cache.define('fetchB', async (query) => {
-    ok('b called')
-    return { j: query }
-  })
-
-  deepStrictEqual(await Promise.all([
-    cache.fetchA(42),
-    cache.fetchB(24)
-  ]), [
-    { k: 42 },
-    { j: 24 }
-  ])
-
-  deepStrictEqual(await Promise.all([
-    cache.fetchA(42),
-    cache.fetchB(24)
-  ]), [
-    { k: 42 },
-    { j: 24 }
-  ])
-
-  await cache.clear('fetchA')
-
-  deepStrictEqual(await Promise.all([
-    cache.fetchA(42),
-    cache.fetchB(24)
-  ]), [
-    { k: 42 },
-    { j: 24 }
-  ])
-})
-
-test('clears only one method with one value', async (t) => {
-  const { ok, deepStrictEqual } = tspl(t, { plan: 5 })
-
-  const cache = new Cache({ ttl: 10, storage: createStorage() })
-
-  cache.define('fetchA', async (query) => {
-    ok('a called')
-    return { k: query }
-  })
-
-  deepStrictEqual(await Promise.all([
-    cache.fetchA(42),
-    cache.fetchA(24)
-  ]), [
-    { k: 42 },
-    { k: 24 }
-  ])
-
-  await cache.clear('fetchA', 42)
-
-  deepStrictEqual(await Promise.all([
-    cache.fetchA(42),
-    cache.fetchA(24)
-  ]), [
-    { k: 42 },
-    { k: 24 }
-  ])
-})
-
-test('throws for methods in the property chain', async function (t) {
-  const cache = new Cache({ storage: createStorage() })
-
-  const keys = [
-    'toString',
-    'hasOwnProperty',
-    'define',
-    'clear'
-  ]
-
-  for (const key of keys) {
-    assert.throws(() => {
-      cache.define(key, () => { })
+    let called = false
+    cache.define('fetchSomething', async (query) => {
+      ok('called')
+      if (!called) {
+        called = true
+        throw new Error('kaboom')
+      }
+      return { k: query }
     })
-  }
-})
 
-test('should cache with references', async function (t) {
-  const { ok } = tspl(t, { plan: 1 })
+    await rejects(cache.fetchSomething(42))
+    deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  })
 
-  const cache = new Cache({ ttl: 60, storage: createStorage() })
+  test('clear the full cache', async (t) => {
+    const { ok, deepStrictEqual } = tspl(t, { plan: 7 })
 
-  cache.define('run', {
-    references: (args, key, result) => {
-      ok('references called')
-      return ['some-reference']
+    const cache = new Cache({ ttl: 1, storage: createStorage() })
+
+    cache.define('fetchA', async (query) => {
+      ok('a called')
+      return { k: query }
+    })
+
+    cache.define('fetchB', async (query) => {
+      ok('b called')
+      return { j: query }
+    })
+
+    deepStrictEqual(await Promise.all([
+      cache.fetchA(42),
+      cache.fetchB(24)
+    ]), [
+      { k: 42 },
+      { j: 24 }
+    ])
+
+    deepStrictEqual(await Promise.all([
+      cache.fetchA(42),
+      cache.fetchB(24)
+    ]), [
+      { k: 42 },
+      { j: 24 }
+    ])
+
+    await cache.clear()
+
+    deepStrictEqual(await Promise.all([
+      cache.fetchA(42),
+      cache.fetchB(24)
+    ]), [
+      { k: 42 },
+      { j: 24 }
+    ])
+  })
+
+  test('clears only one method', async (t) => {
+    const { ok, deepStrictEqual } = tspl(t, { plan: 6 })
+
+    const cache = new Cache({ ttl: 1, storage: createStorage() })
+
+    cache.define('fetchA', async (query) => {
+      ok('a called')
+      return { k: query }
+    })
+
+    cache.define('fetchB', async (query) => {
+      ok('b called')
+      return { j: query }
+    })
+
+    deepStrictEqual(await Promise.all([
+      cache.fetchA(42),
+      cache.fetchB(24)
+    ]), [
+      { k: 42 },
+      { j: 24 }
+    ])
+
+    deepStrictEqual(await Promise.all([
+      cache.fetchA(42),
+      cache.fetchB(24)
+    ]), [
+      { k: 42 },
+      { j: 24 }
+    ])
+
+    await cache.clear('fetchA')
+
+    deepStrictEqual(await Promise.all([
+      cache.fetchA(42),
+      cache.fetchB(24)
+    ]), [
+      { k: 42 },
+      { j: 24 }
+    ])
+  })
+
+  test('clears only one method with one value', async (t) => {
+    const { ok, deepStrictEqual } = tspl(t, { plan: 5 })
+
+    const cache = new Cache({ ttl: 10, storage: createStorage() })
+
+    cache.define('fetchA', async (query) => {
+      ok('a called')
+      return { k: query }
+    })
+
+    deepStrictEqual(await Promise.all([
+      cache.fetchA(42),
+      cache.fetchA(24)
+    ]), [
+      { k: 42 },
+      { k: 24 }
+    ])
+
+    await cache.clear('fetchA', 42)
+
+    deepStrictEqual(await Promise.all([
+      cache.fetchA(42),
+      cache.fetchA(24)
+    ]), [
+      { k: 42 },
+      { k: 24 }
+    ])
+  })
+
+  test('throws for methods in the property chain', async function (t) {
+    const cache = new Cache({ storage: createStorage() })
+
+    const keys = [
+      'toString',
+      'hasOwnProperty',
+      'define',
+      'clear'
+    ]
+
+    for (const key of keys) {
+      assert.throws(() => {
+        cache.define(key, () => { })
+      })
     }
-  }, () => 'something')
+  })
 
-  await cache.run(1)
-})
+  test('should cache with references', async function (t) {
+    const { ok } = tspl(t, { plan: 1 })
 
-test('should handle references function (sync) throwing an error', async function (t) {
-  const { equal } = tspl(t, { plan: 4 })
+    const cache = new Cache({ ttl: 60, storage: createStorage() })
 
-  const cache = new Cache({ ttl: 60, storage: createStorage() })
+    cache.define('run', {
+      references: (args, key, result) => {
+        ok('references called')
+        return ['some-reference']
+      }
+    }, () => 'something')
 
-  cache.define('references', {
-    onError: (err) => { equal(err.message, 'boom') },
-    references: (args, key, result) => { throw new Error('boom') }
-  }, () => 'the-result')
+    await cache.run(1)
+  })
 
-  equal(await cache.references(1), 'the-result')
-  equal(await cache.references(1), 'the-result')
-})
+  test('should handle references function (sync) throwing an error', async function (t) {
+    const { equal } = tspl(t, { plan: 4 })
 
-test('should handle references function (async) throwing an error', async function (t) {
-  const { equal } = tspl(t, { plan: 4 })
+    const cache = new Cache({ ttl: 60, storage: createStorage() })
 
-  const cache = new Cache({ ttl: 60, storage: createStorage() })
+    cache.define('references', {
+      onError: (err) => { equal(err.message, 'boom') },
+      references: (args, key, result) => { throw new Error('boom') }
+    }, () => 'the-result')
 
-  cache.define('references', {
-    onError: (err) => { equal(err.message, 'boom') },
-    references: async (args, key, result) => { throw new Error('boom') }
-  }, () => 'the-result')
+    equal(await cache.references(1), 'the-result')
+    equal(await cache.references(1), 'the-result')
+  })
 
-  equal(await cache.references(1), 'the-result')
-  equal(await cache.references(1), 'the-result')
-})
+  test('should handle references function (async) throwing an error', async function (t) {
+    const { equal } = tspl(t, { plan: 4 })
 
-test('should cache with async references', async function (t) {
-  const { ok } = tspl(t, { plan: 1 })
+    const cache = new Cache({ ttl: 60, storage: createStorage() })
 
-  const cache = new Cache({ ttl: 60, storage: createStorage() })
+    cache.define('references', {
+      onError: (err) => { equal(err.message, 'boom') },
+      references: async (args, key, result) => { throw new Error('boom') }
+    }, () => 'the-result')
 
-  cache.define('run', {
-    references: async (args, key, result) => {
-      ok('references called')
-      return ['some-reference']
+    equal(await cache.references(1), 'the-result')
+    equal(await cache.references(1), 'the-result')
+  })
+
+  test('should cache with async references', async function (t) {
+    const { ok } = tspl(t, { plan: 1 })
+
+    const cache = new Cache({ ttl: 60, storage: createStorage() })
+
+    cache.define('run', {
+      references: async (args, key, result) => {
+        ok('references called')
+        return ['some-reference']
+      }
+    }, () => 'something')
+
+    await cache.run(1)
+  })
+
+  test('should cache with async storage (redis)', async function () {
+    const cache = new Cache({ ttl: 60, storage: createStorage('redis', { client: redisClient }) })
+    cache.define('run', () => 'something')
+    await cache.run(1)
+
+    assert.deepStrictEqual(await cache.run(2), 'something')
+  })
+
+  test('automatically expires with no TTL', async (t) => {
+    // plan verifies that fetchSomething is called only once
+    const { deepStrictEqual, equal } = tspl(t, { plan: 10 })
+
+    let dedupes = 0
+    const cache = new Cache({
+      storage: createStorage(),
+      onDedupe () {
+        dedupes++
+      }
+    })
+
+    const expected = [42, 24, 42]
+
+    cache.define('fetchSomething', async (query, cacheKey) => {
+      deepStrictEqual(query, expected.shift())
+      equal(stringify(query), cacheKey)
+      return { k: query }
+    })
+
+    const p1 = cache.fetchSomething(42)
+    const p2 = cache.fetchSomething(24)
+    const p3 = cache.fetchSomething(42)
+
+    const res = await Promise.all([p1, p2, p3])
+
+    deepStrictEqual(res, [
+      { k: 42 },
+      { k: 24 },
+      { k: 42 }
+    ])
+    equal(dedupes, 1)
+
+    deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+    equal(dedupes, 1)
+  })
+
+  test('calls onError listener', async (t) => {
+    const { equal } = tspl(t, { plan: 2 })
+
+    let onError
+
+    const promise = new Promise((resolve, reject) => {
+      onError = reject
+    })
+
+    const cache = new Cache({ storage: createStorage(), onError })
+
+    cache.define('willDefinitelyWork', async (query, cacheKey) => {
+      throw new Error('whoops')
+    })
+
+    try {
+      await cache.willDefinitelyWork(42)
+      throw new Error('Should throw')
+    } catch (err) {
+      equal(err.message, 'whoops')
     }
-  }, () => 'something')
 
-  await cache.run(1)
-})
-
-test('should cache with async storage (redis)', async function () {
-  const cache = new Cache({ ttl: 60, storage: createStorage('redis', { client: redisClient }) })
-  cache.define('run', () => 'something')
-  await cache.run(1)
-
-  assert.deepStrictEqual(await cache.run(2), 'something')
-})
-
-test('automatically expires with no TTL', async (t) => {
-  // plan verifies that fetchSomething is called only once
-  const { deepStrictEqual, equal } = tspl(t, { plan: 10 })
-
-  let dedupes = 0
-  const cache = new Cache({
-    storage: createStorage(),
-    onDedupe () {
-      dedupes++
+    try {
+      await promise
+      throw new Error('Should throw')
+    } catch (err) {
+      equal(err.message, 'whoops')
     }
   })
 
-  const expected = [42, 24, 42]
+  test('should call onError when serialize throws exception', async (t) => {
+    const { equal } = tspl(t, { plan: 1 })
 
-  cache.define('fetchSomething', async (query, cacheKey) => {
-    deepStrictEqual(query, expected.shift())
-    equal(stringify(query), cacheKey)
-    return { k: query }
+    const serialize = () => {
+      throw new Error('error serializing')
+    }
+
+    const onError = err => equal(err.message, 'error serializing')
+
+    const cache = new Cache({ storage: createStorage(), onError })
+    cache.define('serializeWithError', { serialize }, async k => k)
+
+    await cache.serializeWithError(1)
   })
-
-  const p1 = cache.fetchSomething(42)
-  const p2 = cache.fetchSomething(24)
-  const p3 = cache.fetchSomething(42)
-
-  const res = await Promise.all([p1, p2, p3])
-
-  deepStrictEqual(res, [
-    { k: 42 },
-    { k: 24 },
-    { k: 42 }
-  ])
-  equal(dedupes, 1)
-
-  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
-  equal(dedupes, 1)
-})
-
-test('calls onError listener', async (t) => {
-  const { equal } = tspl(t, { plan: 2 })
-
-  let onError
-
-  const promise = new Promise((resolve, reject) => {
-    onError = reject
-  })
-
-  const cache = new Cache({ storage: createStorage(), onError })
-
-  cache.define('willDefinitelyWork', async (query, cacheKey) => {
-    throw new Error('whoops')
-  })
-
-  try {
-    await cache.willDefinitelyWork(42)
-    throw new Error('Should throw')
-  } catch (err) {
-    equal(err.message, 'whoops')
-  }
-
-  try {
-    await promise
-    throw new Error('Should throw')
-  } catch (err) {
-    equal(err.message, 'whoops')
-  }
-})
-
-test('should call onError when serialize throws exception', async (t) => {
-  const { equal } = tspl(t, { plan: 1 })
-
-  const serialize = () => {
-    throw new Error('error serializing')
-  }
-
-  const onError = err => equal(err.message, 'error serializing')
-
-  const cache = new Cache({ storage: createStorage(), onError })
-  cache.define('serializeWithError', { serialize }, async k => k)
-
-  await cache.serializeWithError(1)
 })

--- a/test/clear.test.js
+++ b/test/clear.test.js
@@ -90,7 +90,7 @@ test('clears only one method', async (t) => {
 })
 
 test('clears only one method with one value', async (t) => {
-  const { ok, deepStrictEqual } = tspl(t, { plan: 6 })
+  const { ok, deepStrictEqual } = tspl(t, { plan: 5 })
 
   const cache = new Cache({ ttl: 42, storage: createStorage() })
 

--- a/test/clear.test.js
+++ b/test/clear.test.js
@@ -1,29 +1,26 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
+const { tspl } = require('@matteo.collina/tspl')
 const { Cache } = require('../src/cache')
 const createStorage = require('../src/storage')
 
-const { test } = t
-
-t.jobs = 3
-
 test('clear the full cache', async (t) => {
-  t.plan(7)
+  const { ok, deepStrictEqual } = tspl(t, { plan: 7 })
 
   const cache = new Cache({ ttl: 42, storage: createStorage() })
 
   cache.define('fetchA', async (query) => {
-    t.pass('a called')
+    ok('a called')
     return { k: query }
   })
 
   cache.define('fetchB', async (query) => {
-    t.pass('b called')
+    ok('b called')
     return { j: query }
   })
 
-  t.same(await Promise.all([
+  deepStrictEqual(await Promise.all([
     cache.fetchA(42),
     cache.fetchB(24)
   ]), [
@@ -31,7 +28,7 @@ test('clear the full cache', async (t) => {
     { j: 24 }
   ])
 
-  t.same(await Promise.all([
+  deepStrictEqual(await Promise.all([
     cache.fetchA(42),
     cache.fetchB(24)
   ]), [
@@ -41,7 +38,7 @@ test('clear the full cache', async (t) => {
 
   cache.clear()
 
-  t.same(await Promise.all([
+  deepStrictEqual(await Promise.all([
     cache.fetchA(42),
     cache.fetchB(24)
   ]), [
@@ -51,21 +48,21 @@ test('clear the full cache', async (t) => {
 })
 
 test('clears only one method', async (t) => {
-  t.plan(6)
+  const { ok, deepStrictEqual } = tspl(t, { plan: 6 })
 
   const cache = new Cache({ ttl: 42, storage: createStorage() })
 
   cache.define('fetchA', async (query) => {
-    t.pass('a called')
+    ok('a called')
     return { k: query }
   })
 
   cache.define('fetchB', async (query) => {
-    t.pass('b called')
+    ok('b called')
     return { j: query }
   })
 
-  t.same(await Promise.all([
+  deepStrictEqual(await Promise.all([
     cache.fetchA(42),
     cache.fetchB(24)
   ]), [
@@ -73,7 +70,7 @@ test('clears only one method', async (t) => {
     { j: 24 }
   ])
 
-  t.same(await Promise.all([
+  deepStrictEqual(await Promise.all([
     cache.fetchA(42),
     cache.fetchB(24)
   ]), [
@@ -83,7 +80,7 @@ test('clears only one method', async (t) => {
 
   cache.clear('fetchA')
 
-  t.same(await Promise.all([
+  deepStrictEqual(await Promise.all([
     cache.fetchA(42),
     cache.fetchB(24)
   ]), [
@@ -93,16 +90,16 @@ test('clears only one method', async (t) => {
 })
 
 test('clears only one method with one value', async (t) => {
-  t.plan(5)
+  const { ok, deepStrictEqual } = tspl(t, { plan: 6 })
 
   const cache = new Cache({ ttl: 42, storage: createStorage() })
 
   cache.define('fetchA', async (query) => {
-    t.pass('a called')
+    ok('a called')
     return { k: query }
   })
 
-  t.same(await Promise.all([
+  deepStrictEqual(await Promise.all([
     cache.fetchA(42),
     cache.fetchA(24)
   ]), [
@@ -112,7 +109,7 @@ test('clears only one method with one value', async (t) => {
 
   cache.clear('fetchA', 42)
 
-  t.same(await Promise.all([
+  deepStrictEqual(await Promise.all([
     cache.fetchA(42),
     cache.fetchA(24)
   ]), [

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -1,18 +1,15 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
+const { tspl } = require('@matteo.collina/tspl')
 const { promisify } = require('util')
 const { Cache } = require('../src/cache')
 const createStorage = require('../src/storage')
 
 const sleep = promisify(setTimeout)
 
-const { test } = t
-
-t.jobs = 3
-
 test('stale', async (t) => {
-  t.plan(11)
+  const { equal, deepStrictEqual } = tspl(t, { plan: 11 })
 
   const storage = createStorage()
 
@@ -25,43 +22,43 @@ test('stale', async (t) => {
   let toReturn = 42
 
   cache.define('fetchSomething', async (query) => {
-    t.equal(query, 42)
+    equal(query, 42)
     return { k: toReturn }
   })
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 
-  t.equal(storage.getTTL('fetchSomething~42'), 10)
+  equal(storage.getTTL('fetchSomething~42'), 10)
   await sleep(2500)
-  t.equal(storage.getTTL('fetchSomething~42') < 10, true)
+  equal(storage.getTTL('fetchSomething~42') < 10, true)
 
   // This value will be revalidated
   toReturn++
-  t.same(await cache.fetchSomething(42), { k: 42 })
-  t.equal(storage.getTTL('fetchSomething~42'), 10)
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  equal(storage.getTTL('fetchSomething~42'), 10)
 
   await sleep(500)
 
-  t.same(await cache.fetchSomething(42), { k: 43 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 43 })
 
-  t.same(await cache.fetchSomething(42), { k: 43 })
-  t.equal(storage.getTTL('fetchSomething~42'), 10)
+  deepStrictEqual(await cache.fetchSomething(42), { k: 43 })
+  equal(storage.getTTL('fetchSomething~42'), 10)
 })
 
 test('global stale is a positive integer', async (t) => {
-  t.plan(1)
+  const { equal } = tspl(t, { plan: 1 })
 
   try {
     // eslint-disable-next-line no-new
     new Cache({ ttl: 42, stale: 3.14, storage: createStorage() })
   } catch (err) {
-    t.equal(err.message, 'stale must be an integer greater or equal to 0')
+    equal(err.message, 'stale must be an integer greater or equal to 0')
   }
 })
 
 test('stale as parameter', async (t) => {
-  t.plan(6)
+  const { equal, deepStrictEqual } = tspl(t, { plan: 6 })
 
   const cache = new Cache({
     storage: createStorage(),
@@ -69,24 +66,24 @@ test('stale as parameter', async (t) => {
   })
 
   cache.define('fetchSomething', { stale: 9 }, async (query) => {
-    t.equal(query, 42)
+    equal(query, 42)
     return { k: query }
   })
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 
   await sleep(2500)
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 
   await sleep(500)
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 })
 
 test('stale as a function', async (t) => {
-  t.plan(11)
+  const { equal, deepStrictEqual } = tspl(t, { plan: 11 })
 
   const storage = createStorage()
 
@@ -99,32 +96,32 @@ test('stale as a function', async (t) => {
   let toReturn = 42
 
   cache.define('fetchSomething', async (query) => {
-    t.equal(query, 42)
+    equal(query, 42)
     return { k: toReturn, stale: 9 }
   })
 
-  t.same(await cache.fetchSomething(42), { k: 42, stale: 9 })
-  t.same(await cache.fetchSomething(42), { k: 42, stale: 9 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42, stale: 9 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42, stale: 9 })
 
-  t.equal(storage.getTTL('fetchSomething~42'), 10)
+  equal(storage.getTTL('fetchSomething~42'), 10)
   await sleep(2500)
-  t.equal(storage.getTTL('fetchSomething~42') < 10, true)
+  equal(storage.getTTL('fetchSomething~42') < 10, true)
 
   // This value will be revalidated
   toReturn++
-  t.same(await cache.fetchSomething(42), { k: 42, stale: 9 })
-  t.equal(storage.getTTL('fetchSomething~42'), 10)
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42, stale: 9 })
+  equal(storage.getTTL('fetchSomething~42'), 10)
 
   await sleep(500)
 
-  t.same(await cache.fetchSomething(42), { k: 43, stale: 9 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 43, stale: 9 })
 
-  t.same(await cache.fetchSomething(42), { k: 43, stale: 9 })
-  t.equal(storage.getTTL('fetchSomething~42'), 10)
+  deepStrictEqual(await cache.fetchSomething(42), { k: 43, stale: 9 })
+  equal(storage.getTTL('fetchSomething~42'), 10)
 })
 
 test('stale as a function parameter', async (t) => {
-  t.plan(6)
+  const { equal, deepStrictEqual } = tspl(t, { plan: 6 })
 
   const cache = new Cache({
     storage: createStorage(),
@@ -132,18 +129,18 @@ test('stale as a function parameter', async (t) => {
   })
 
   cache.define('fetchSomething', { stale: () => 9 }, async (query) => {
-    t.equal(query, 42)
+    equal(query, 42)
     return { k: query }
   })
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 
   await sleep(2500)
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 
   await sleep(500)
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 })

--- a/test/storage-base.test.js
+++ b/test/storage-base.test.js
@@ -1,20 +1,19 @@
 'use strict'
 
-const t = require('tap')
+const { test, describe } = require('node:test')
+const assert = require('assert')
 const createStorage = require('../src/storage')
 const StorageInterface = require('../src/storage/interface')
 
-const { test } = t
-
-test('storage', async (t) => {
+describe('storage', async (t) => {
   test('should get an instance with default options', async (t) => {
     const storage = createStorage()
 
-    t.ok(typeof storage.get === 'function')
-    t.ok(typeof storage.set === 'function')
-    t.ok(typeof storage.remove === 'function')
-    t.ok(typeof storage.invalidate === 'function')
-    t.ok(typeof storage.refresh === 'function')
+    assert.ok(typeof storage.get === 'function')
+    assert.ok(typeof storage.set === 'function')
+    assert.ok(typeof storage.remove === 'function')
+    assert.ok(typeof storage.invalidate === 'function')
+    assert.ok(typeof storage.refresh === 'function')
   })
 
   test('should get an error implementing storage interfaces without get method', async (t) => {
@@ -25,9 +24,9 @@ test('storage', async (t) => {
     for (const method of ['get', 'set', 'remove', 'invalidate', 'clear', 'refresh']) {
       try {
         await badStorage[method]()
-        t.fail(`should throw an error on method ${method}`)
+        assert.fail(`should throw an error on method ${method}`)
       } catch (err) {
-        t.equal(err.message, `storage ${method} method not implemented`)
+        assert.equal(err.message, `storage ${method} method not implemented`)
       }
     }
   })

--- a/test/storage-memory.test.js
+++ b/test/storage-memory.test.js
@@ -1,171 +1,171 @@
 'use strict'
 
-const t = require('tap')
+const { test, describe } = require('node:test')
+const assert = require('node:assert')
+const { tspl } = require('@matteo.collina/tspl')
 const createStorage = require('../src/storage')
 const { promisify } = require('util')
 
 const sleep = promisify(setTimeout)
 
-const { test } = t
-
-test('storage memory', async (t) => {
-  test('should get an instance with default options', async (t) => {
+describe('storage memory', async () => {
+  test('should get an instance with default options', async () => {
     const storage = createStorage('memory')
 
-    t.ok(typeof storage.get === 'function')
-    t.ok(typeof storage.set === 'function')
-    t.ok(typeof storage.remove === 'function')
-    t.ok(typeof storage.invalidate === 'function')
-    t.ok(typeof storage.refresh === 'function')
+    assert.ok(typeof storage.get === 'function')
+    assert.ok(typeof storage.set === 'function')
+    assert.ok(typeof storage.remove === 'function')
+    assert.ok(typeof storage.invalidate === 'function')
+    assert.ok(typeof storage.refresh === 'function')
 
-    t.equal(storage.store.capacity, 1024)
+    assert.equal(storage.store.capacity, 1024)
   })
 
-  test('should get an error on invalid options', async (t) => {
-    t.throws(() => createStorage('memory', { size: -1 }), /size must be a positive integer greater than 0/)
+  test('should get an error on invalid options', async () => {
+    assert.throws(() => createStorage('memory', { size: -1 }), /size must be a positive integer greater than 0/)
   })
 
-  test('should not initialize references containeres on invalidation disabled', async (t) => {
+  test('should not initialize references containeres on invalidation disabled', async () => {
     const storage = createStorage('memory')
 
-    t.equal(storage.keysReferences, undefined)
-    t.equal(storage.referencesKeys, undefined)
+    assert.equal(storage.keysReferences, undefined)
+    assert.equal(storage.referencesKeys, undefined)
   })
 
-  test('should initialize references containeres on invalidation enabled', async (t) => {
+  test('should initialize references containeres on invalidation enabled', async () => {
     const storage = createStorage('memory', { invalidation: true })
 
-    t.ok(typeof storage.keysReferences === 'object')
-    t.ok(typeof storage.referencesKeys === 'object')
+    assert.ok(typeof storage.keysReferences === 'object')
+    assert.ok(typeof storage.referencesKeys === 'object')
   })
 
-  test('get', async (t) => {
-    test('should get a value by a key previously stored', async (t) => {
+  describe('get', async () => {
+    test('should get a value by a key previously stored', async () => {
       const storage = createStorage('memory')
 
       storage.set('foo', 'bar', 100)
 
-      t.equal(storage.get('foo'), 'bar')
+      assert.equal(storage.get('foo'), 'bar')
     })
 
-    test('should get undefined retrieving a non stored key', async (t) => {
+    test('should get undefined retrieving a non stored key', async () => {
       const storage = createStorage('memory')
 
       storage.set('foo', 'bar', 100)
 
-      t.equal(storage.get('no-foo'), undefined)
+      assert.equal(storage.get('no-foo'), undefined)
     })
 
-    test('should get undefined retrieving an expired value', async (t) => {
+    test('should get undefined retrieving an expired value', async () => {
       const storage = createStorage('memory')
 
       storage.set('foo', 'bar', 1)
       await sleep(2000)
 
-      t.equal(storage.get('foo'), undefined)
+      assert.equal(storage.get('foo'), undefined)
     })
   })
 
-  test('getTTL', async (t) => {
-    test('should get the TTL of a previously key stored', async (t) => {
+  describe('getTTL', async () => {
+    test('should get the TTL of a previously key stored', async () => {
       const storage = createStorage('memory')
 
       storage.set('foo', 'bar', 100)
 
-      t.equal(storage.getTTL('foo'), 100)
+      assert.equal(storage.getTTL('foo'), 100)
 
       await sleep(1000)
 
-      t.equal(storage.getTTL('foo'), 99)
+      assert.equal(storage.getTTL('foo'), 99)
     })
 
-    test('should get the TTL of a a key without TTL', async (t) => {
+    test('should get the TTL of a a key without TTL', async () => {
       const storage = createStorage('memory')
 
       storage.set('foo', 'bar', 0)
 
-      t.equal(storage.getTTL('foo'), 0)
+      assert.equal(storage.getTTL('foo'), 0)
     })
 
-    test('should get the TTL of a previously key stored', async (t) => {
+    test('should get the TTL of a previously key stored', async () => {
       const storage = createStorage('memory')
 
       storage.set('foo', 'bar', 1)
 
-      t.equal(storage.getTTL('foo'), 1)
+      assert.equal(storage.getTTL('foo'), 1)
 
       await sleep(1000)
 
-      t.equal(storage.getTTL('foo'), 0)
+      assert.equal(storage.getTTL('foo'), 0)
     })
 
-    test('no key', async (t) => {
+    test('no key', async () => {
       const storage = createStorage('memory')
 
-      t.equal(storage.getTTL('foo'), 0)
+      assert.equal(storage.getTTL('foo'), 0)
     })
 
-    test('should get the TTL of a previously key stored', async (t) => {
+    test('should get the TTL of a previously key stored', async () => {
       const storage = createStorage('memory')
 
       storage.set('foo', 'bar', 1)
 
       await sleep(2000)
 
-      t.equal(storage.getTTL('foo'), 0)
+      assert.equal(storage.getTTL('foo'), 0)
     })
   })
 
-  test('set', async (t) => {
-    test('should set a value, with ttl', async (t) => {
+  describe('set', async () => {
+    test('should set a value, with ttl', async () => {
       const storage = createStorage('memory')
       storage.set('foo', 'bar', 1)
 
       const stored = storage.store.get('foo')
 
-      t.equal(stored.value, 'bar')
-      t.equal(stored.ttl, 1)
-      t.ok(stored.start < Date.now())
+      assert.equal(stored.value, 'bar')
+      assert.equal(stored.ttl, 1)
+      assert.ok(stored.start < Date.now())
     })
 
-    test('should not set a value with ttl < 1', async (t) => {
+    test('should not set a value with ttl < 1', async () => {
       const storage = createStorage('memory')
 
       storage.set('foo', 'bar', 0)
 
-      t.equal(storage.get('foo'), undefined)
+      assert.equal(storage.get('foo'), undefined)
     })
 
-    test('should set a value with references', async (t) => {
+    test('should set a value with references', async () => {
       const storage = createStorage('memory', { invalidation: true })
 
       storage.set('foo', 'bar', 100, ['fooers'])
 
       const stored = storage.store.get('foo')
-      t.equal(stored.value, 'bar')
-      t.same(storage.referencesKeys.get('fooers'), ['foo'])
-      t.same(storage.keysReferences.get('foo'), ['fooers'])
+      assert.equal(stored.value, 'bar')
+      assert.deepStrictEqual(storage.referencesKeys.get('fooers'), ['foo'])
+      assert.deepStrictEqual(storage.keysReferences.get('foo'), ['fooers'])
     })
 
-    test('should not set an empty references', async (t) => {
+    test('should not set an empty references', async () => {
       const storage = createStorage('memory', { invalidation: true })
 
       storage.set('foo', 'bar', 100, [])
 
       const stored = storage.store.get('foo')
-      t.equal(stored.value, 'bar')
-      t.same(storage.referencesKeys.size, 0)
-      t.same(storage.keysReferences.size, 0)
+      assert.equal(stored.value, 'bar')
+      assert.deepStrictEqual(storage.referencesKeys.size, 0)
+      assert.deepStrictEqual(storage.keysReferences.size, 0)
     })
 
     test('should get a warning setting references with invalidation disabled', async (t) => {
-      t.plan(1)
+      const { equal } = tspl(t, { plan: 1 })
 
       const storage = createStorage('memory', {
         log: {
           debug: () => { },
           warn: (error) => {
-            t.equal(error.msg, 'acd/storage/memory.set, invalidation is disabled, references are useless')
+            equal(error.msg, 'acd/storage/memory.set, invalidation is disabled, references are useless')
           }
         }
       })
@@ -173,98 +173,98 @@ test('storage memory', async (t) => {
       storage.set('foo', 'bar', 1, ['fooers'])
     })
 
-    test('should not set a references twice', async (t) => {
+    test('should not set a references twice', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo', 'bar', 1, ['fooers'])
       storage.set('foo', 'new-bar', 1, ['fooers'])
 
       const stored = storage.store.get('foo')
-      t.equal(stored.value, 'new-bar')
-      t.same(storage.referencesKeys.get('fooers'), ['foo'])
-      t.same(storage.keysReferences.get('foo'), ['fooers'])
+      assert.equal(stored.value, 'new-bar')
+      assert.deepStrictEqual(storage.referencesKeys.get('fooers'), ['foo'])
+      assert.deepStrictEqual(storage.keysReferences.get('foo'), ['fooers'])
     })
 
-    test('should add a key to an existing reference', async (t) => {
+    test('should add a key to an existing reference', async () => {
       const storage = createStorage('memory', { invalidation: true })
 
       storage.set('foo1', 'bar1', 1, ['fooers'])
       storage.set('foo2', 'bar2', 1, ['fooers'])
 
-      t.same(storage.referencesKeys.get('fooers'), ['foo1', 'foo2'])
-      t.same(storage.keysReferences.get('foo1'), ['fooers'])
-      t.same(storage.keysReferences.get('foo2'), ['fooers'])
+      assert.deepStrictEqual(storage.referencesKeys.get('fooers'), ['foo1', 'foo2'])
+      assert.deepStrictEqual(storage.keysReferences.get('foo1'), ['fooers'])
+      assert.deepStrictEqual(storage.keysReferences.get('foo2'), ['fooers'])
     })
 
-    test('should update the key references, full replace', async (t) => {
+    test('should update the key references, full replace', async () => {
       const storage = createStorage('memory', { invalidation: true })
 
       storage.set('foo', 'bar1', 100, ['fooers', 'mooers'])
       storage.set('foo', 'bar2', 100, ['booers', 'tooers'])
 
-      t.equal(storage.referencesKeys.get('fooers'), undefined)
-      t.equal(storage.referencesKeys.get('mooers'), undefined)
-      t.same(storage.referencesKeys.get('booers'), ['foo'])
-      t.same(storage.referencesKeys.get('tooers'), ['foo'])
+      assert.equal(storage.referencesKeys.get('fooers'), undefined)
+      assert.equal(storage.referencesKeys.get('mooers'), undefined)
+      assert.deepStrictEqual(storage.referencesKeys.get('booers'), ['foo'])
+      assert.deepStrictEqual(storage.referencesKeys.get('tooers'), ['foo'])
 
-      t.same(storage.keysReferences.get('foo'), ['booers', 'tooers'])
+      assert.deepStrictEqual(storage.keysReferences.get('foo'), ['booers', 'tooers'])
     })
 
-    test('should update the key references, partial replace', async (t) => {
+    test('should update the key references, partial replace', async () => {
       const storage = createStorage('memory', { invalidation: true })
 
       storage.set('foo', 'bar1', 100, ['fooers', 'mooers'])
       storage.set('foo', 'bar2', 100, ['mooers', 'tooers'])
 
-      t.equal(storage.referencesKeys.get('fooers'), undefined)
-      t.same(storage.referencesKeys.get('mooers'), ['foo'])
-      t.same(storage.referencesKeys.get('tooers'), ['foo'])
+      assert.equal(storage.referencesKeys.get('fooers'), undefined)
+      assert.deepStrictEqual(storage.referencesKeys.get('mooers'), ['foo'])
+      assert.deepStrictEqual(storage.referencesKeys.get('tooers'), ['foo'])
 
-      t.same(storage.keysReferences.get('foo'), ['mooers', 'tooers'])
+      assert.deepStrictEqual(storage.keysReferences.get('foo'), ['mooers', 'tooers'])
     })
 
-    test('should update the key references, partial replace adding more references', async (t) => {
+    test('should update the key references, partial replace adding more references', async () => {
       const storage = createStorage('memory', { invalidation: true })
 
       storage.set('foo', 'bar1', 100, ['a', 'b'])
       storage.set('foo', 'bar2', 100, ['z', 'b', 'd'])
 
-      t.equal(storage.referencesKeys.get('a'), undefined)
-      t.same(storage.referencesKeys.get('b'), ['foo'])
-      t.same(storage.referencesKeys.get('d'), ['foo'])
-      t.same(storage.referencesKeys.get('z'), ['foo'])
+      assert.equal(storage.referencesKeys.get('a'), undefined)
+      assert.deepStrictEqual(storage.referencesKeys.get('b'), ['foo'])
+      assert.deepStrictEqual(storage.referencesKeys.get('d'), ['foo'])
+      assert.deepStrictEqual(storage.referencesKeys.get('z'), ['foo'])
 
-      t.same(storage.keysReferences.get('foo'), ['b', 'd', 'z'])
+      assert.deepStrictEqual(storage.keysReferences.get('foo'), ['b', 'd', 'z'])
     })
 
-    test('should update the key references, partial replace with shared reference', async (t) => {
+    test('should update the key references, partial replace with shared reference', async () => {
       const storage = createStorage('memory', { invalidation: true })
 
       storage.set('boo', 'bar1', 100, ['a', 'b'])
       storage.set('foo', 'bar1', 100, ['a', 'b'])
       storage.set('foo', 'bar2', 100, ['z', 'b', 'd'])
 
-      t.same(storage.referencesKeys.get('a'), ['boo'])
-      t.same(storage.referencesKeys.get('b'), ['boo', 'foo'])
-      t.same(storage.referencesKeys.get('d'), ['foo'])
-      t.same(storage.referencesKeys.get('z'), ['foo'])
+      assert.deepStrictEqual(storage.referencesKeys.get('a'), ['boo'])
+      assert.deepStrictEqual(storage.referencesKeys.get('b'), ['boo', 'foo'])
+      assert.deepStrictEqual(storage.referencesKeys.get('d'), ['foo'])
+      assert.deepStrictEqual(storage.referencesKeys.get('z'), ['foo'])
 
-      t.same(storage.keysReferences.get('foo'), ['b', 'd', 'z'])
+      assert.deepStrictEqual(storage.keysReferences.get('foo'), ['b', 'd', 'z'])
     })
 
-    test('should update the key references, add reference to existing key without them', async (t) => {
+    test('should update the key references, add reference to existing key without them', async () => {
       const storage = createStorage('memory', { invalidation: true })
 
       storage.set('key1', {}, 2)
       storage.set('key1', 'another value', 2, ['a', 'b', 'c'])
 
-      t.same(storage.referencesKeys.get('a'), ['key1'])
-      t.same(storage.referencesKeys.get('b'), ['key1'])
-      t.same(storage.referencesKeys.get('c'), ['key1'])
+      assert.deepStrictEqual(storage.referencesKeys.get('a'), ['key1'])
+      assert.deepStrictEqual(storage.referencesKeys.get('b'), ['key1'])
+      assert.deepStrictEqual(storage.referencesKeys.get('c'), ['key1'])
 
-      t.same(storage.keysReferences.get('key1'), ['a', 'b', 'c'])
+      assert.deepStrictEqual(storage.keysReferences.get('key1'), ['a', 'b', 'c'])
     })
 
-    test('should update references of evicted keys (removed by size)', async (t) => {
+    test('should update references of evicted keys (removed by size)', async () => {
       const storage = createStorage('memory', { size: 2, invalidation: true })
 
       storage.set('foo1', 'a', 100, ['foo:1', 'fooers'])
@@ -272,60 +272,60 @@ test('storage memory', async (t) => {
       storage.set('foo3', 'c', 100, ['foo:3', 'fooers'])
       storage.set('foo4', 'd', 100, ['foo:4', 'fooers'])
 
-      t.equal(storage.store.get('foo1'), undefined)
-      t.equal(storage.store.get('foo2'), undefined)
-      t.equal(storage.store.get('foo3').value, 'c')
-      t.equal(storage.store.get('foo4').value, 'd')
+      assert.equal(storage.store.get('foo1'), undefined)
+      assert.equal(storage.store.get('foo2'), undefined)
+      assert.equal(storage.store.get('foo3').value, 'c')
+      assert.equal(storage.store.get('foo4').value, 'd')
 
-      t.same(storage.referencesKeys.get('fooers'), ['foo3', 'foo4'])
+      assert.deepStrictEqual(storage.referencesKeys.get('fooers'), ['foo3', 'foo4'])
 
-      t.same(storage.keysReferences.get('foo1'), undefined)
-      t.same(storage.keysReferences.get('foo2'), undefined)
-      t.same(storage.keysReferences.get('foo3'), ['foo:3', 'fooers'])
-      t.same(storage.keysReferences.get('foo4'), ['foo:4', 'fooers'])
+      assert.deepStrictEqual(storage.keysReferences.get('foo1'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('foo2'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('foo3'), ['foo:3', 'fooers'])
+      assert.deepStrictEqual(storage.keysReferences.get('foo4'), ['foo:4', 'fooers'])
     })
   })
 
-  test('remove', async (t) => {
-    test('should remove an existing key', async (t) => {
+  describe('remove', async () => {
+    test('should remove an existing key', async () => {
       const storage = createStorage('memory')
       storage.set('foo', 'bar', 10)
 
-      t.equal(storage.remove('foo'), true)
+      assert.equal(storage.remove('foo'), true)
 
-      t.equal(storage.get('foo'), undefined)
+      assert.equal(storage.get('foo'), undefined)
     })
 
-    test('should remove an non existing key', async (t) => {
+    test('should remove an non existing key', async () => {
       const storage = createStorage('memory')
       storage.set('foo', 'bar', 10)
 
-      t.equal(storage.remove('fooz'), false)
+      assert.equal(storage.remove('fooz'), false)
 
-      t.equal(storage.get('foo'), 'bar')
-      t.equal(storage.get('fooz'), undefined)
+      assert.equal(storage.get('foo'), 'bar')
+      assert.equal(storage.get('fooz'), undefined)
     })
 
-    test('should remove an existing key and references', async (t) => {
+    test('should remove an existing key and references', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo', 'bar', 10, ['fooers'])
 
-      t.equal(storage.remove('foo'), true)
+      assert.equal(storage.remove('foo'), true)
 
-      t.equal(storage.get('foo'), undefined)
+      assert.equal(storage.get('foo'), undefined)
     })
 
-    test('should remove an non existing key (and references)', async (t) => {
+    test('should remove an non existing key (and references)', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo', 'bar', 10, ['fooers'])
 
-      t.equal(storage.remove('fooz'), false)
+      assert.equal(storage.remove('fooz'), false)
 
-      t.equal(storage.get('foo'), 'bar')
-      t.equal(storage.get('fooz'), undefined)
+      assert.equal(storage.get('foo'), 'bar')
+      assert.equal(storage.get('fooz'), undefined)
     })
 
-    test('should remove a key but not references if still active', async (t) => {
+    test('should remove a key but not references if still active', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('a', 1, 10, ['fooers', 'vowels'])
       storage.set('b', 1, 10, ['fooers', 'consonantes'])
@@ -333,28 +333,28 @@ test('storage memory', async (t) => {
       storage.set('d', 1, 10, ['consonantes'])
       storage.set('e', 1, 10, ['vowels'])
 
-      t.equal(storage.remove('a'), true)
+      assert.equal(storage.remove('a'), true)
 
-      t.equal(storage.get('a'), undefined)
-      t.equal(storage.get('b'), 1)
-      t.equal(storage.get('c'), 1)
-      t.equal(storage.get('d'), 1)
-      t.equal(storage.get('e'), 1)
+      assert.equal(storage.get('a'), undefined)
+      assert.equal(storage.get('b'), 1)
+      assert.equal(storage.get('c'), 1)
+      assert.equal(storage.get('d'), 1)
+      assert.equal(storage.get('e'), 1)
 
-      t.same(storage.referencesKeys.get('fooers'), ['b', 'c'])
-      t.same(storage.referencesKeys.get('consonantes'), ['b', 'c', 'd'])
-      t.same(storage.referencesKeys.get('vowels'), ['e'])
+      assert.deepStrictEqual(storage.referencesKeys.get('fooers'), ['b', 'c'])
+      assert.deepStrictEqual(storage.referencesKeys.get('consonantes'), ['b', 'c', 'd'])
+      assert.deepStrictEqual(storage.referencesKeys.get('vowels'), ['e'])
 
-      t.same(storage.keysReferences.get('a'), undefined)
-      t.same(storage.keysReferences.get('b'), ['fooers', 'consonantes'])
-      t.same(storage.keysReferences.get('c'), ['fooers', 'consonantes'])
-      t.same(storage.keysReferences.get('d'), ['consonantes'])
-      t.same(storage.keysReferences.get('e'), ['vowels'])
+      assert.deepStrictEqual(storage.keysReferences.get('a'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('b'), ['fooers', 'consonantes'])
+      assert.deepStrictEqual(storage.keysReferences.get('c'), ['fooers', 'consonantes'])
+      assert.deepStrictEqual(storage.keysReferences.get('d'), ['consonantes'])
+      assert.deepStrictEqual(storage.keysReferences.get('e'), ['vowels'])
     })
   })
 
-  test('invalidate', async (t) => {
-    test('should remove storage keys by references', async (t) => {
+  describe('invalidate', async () => {
+    test('should remove storage keys by references', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo~1', 'bar', 1, ['fooers', 'foo:1'])
       storage.set('foo~2', 'baz', 1, ['fooers', 'foo:2'])
@@ -362,23 +362,23 @@ test('storage memory', async (t) => {
 
       const removed = storage.invalidate(['fooers'])
 
-      t.same(removed, ['foo~1', 'foo~2'])
+      assert.deepStrictEqual(removed, ['foo~1', 'foo~2'])
 
-      t.equal(storage.get('foo~1'), undefined)
-      t.equal(storage.get('foo~2'), undefined)
-      t.equal(storage.get('boo~1'), 'fiz')
+      assert.equal(storage.get('foo~1'), undefined)
+      assert.equal(storage.get('foo~2'), undefined)
+      assert.equal(storage.get('boo~1'), 'fiz')
 
-      t.equal(storage.referencesKeys.get('fooers'), undefined)
-      t.equal(storage.referencesKeys.get('foo:1'), undefined)
-      t.equal(storage.referencesKeys.get('foo:2'), undefined)
-      t.same(storage.referencesKeys.get('booers'), ['boo~1'])
+      assert.equal(storage.referencesKeys.get('fooers'), undefined)
+      assert.equal(storage.referencesKeys.get('foo:1'), undefined)
+      assert.equal(storage.referencesKeys.get('foo:2'), undefined)
+      assert.deepStrictEqual(storage.referencesKeys.get('booers'), ['boo~1'])
 
-      t.equal(storage.keysReferences.get('foo~1'), undefined)
-      t.equal(storage.keysReferences.get('foo~2'), undefined)
-      t.same(storage.keysReferences.get('boo~1'), ['booers', 'boo:1'])
+      assert.equal(storage.keysReferences.get('foo~1'), undefined)
+      assert.equal(storage.keysReferences.get('foo~2'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('boo~1'), ['booers', 'boo:1'])
     })
 
-    test('should not remove storage keys by not existing reference', async (t) => {
+    test('should not remove storage keys by not existing reference', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo~1', 'bar', 1, ['fooers', 'foo:1'])
       storage.set('foo~2', 'baz', 1, ['fooers', 'foo:2'])
@@ -386,14 +386,14 @@ test('storage memory', async (t) => {
 
       const removed = storage.invalidate(['buzzers'])
 
-      t.same(removed, [])
+      assert.deepStrictEqual(removed, [])
 
-      t.equal(storage.get('foo~1'), 'bar')
-      t.equal(storage.get('foo~2'), 'baz')
-      t.equal(storage.get('boo~1'), 'fiz')
+      assert.equal(storage.get('foo~1'), 'bar')
+      assert.equal(storage.get('foo~2'), 'baz')
+      assert.equal(storage.get('boo~1'), 'fiz')
     })
 
-    test('should invalide more than one reference at once', async (t) => {
+    test('should invalide more than one reference at once', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo~1', 'bar', 1, ['fooers', 'foo:1'])
       storage.set('foo~2', 'baz', 1, ['fooers', 'foo:2'])
@@ -401,14 +401,14 @@ test('storage memory', async (t) => {
 
       const removed = storage.invalidate(['fooers', 'booers'])
 
-      t.same(removed, ['foo~1', 'foo~2', 'boo~1'])
+      assert.deepStrictEqual(removed, ['foo~1', 'foo~2', 'boo~1'])
 
-      t.equal(storage.get('foo~1'), undefined)
-      t.equal(storage.get('foo~2'), undefined)
-      t.equal(storage.get('boo~1'), undefined)
+      assert.equal(storage.get('foo~1'), undefined)
+      assert.equal(storage.get('foo~2'), undefined)
+      assert.equal(storage.get('boo~1'), undefined)
     })
 
-    test('should remove storage keys by references, but not the ones still alive', async (t) => {
+    test('should remove storage keys by references, but not the ones still alive', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo~1', 'bar', 1, ['fooers', 'foo:1'])
       storage.set('foo~boo', 'baz', 1, ['fooers', 'booers'])
@@ -416,22 +416,22 @@ test('storage memory', async (t) => {
 
       const removed = storage.invalidate(['fooers'])
 
-      t.same(removed, ['foo~1', 'foo~boo'])
+      assert.deepStrictEqual(removed, ['foo~1', 'foo~boo'])
 
-      t.equal(storage.get('foo~1'), undefined)
-      t.equal(storage.get('boo~1'), 'fiz')
-      t.equal(storage.get('foo~boo'), undefined)
+      assert.equal(storage.get('foo~1'), undefined)
+      assert.equal(storage.get('boo~1'), 'fiz')
+      assert.equal(storage.get('foo~boo'), undefined)
 
-      t.equal(storage.referencesKeys.get('fooers'), undefined)
-      t.equal(storage.referencesKeys.get('foo:1'), undefined)
-      t.same(storage.referencesKeys.get('booers'), ['boo~1'])
+      assert.equal(storage.referencesKeys.get('fooers'), undefined)
+      assert.equal(storage.referencesKeys.get('foo:1'), undefined)
+      assert.deepStrictEqual(storage.referencesKeys.get('booers'), ['boo~1'])
 
-      t.equal(storage.keysReferences.get('foo~1'), undefined)
-      t.equal(storage.keysReferences.get('foo~boo'), undefined)
-      t.same(storage.keysReferences.get('boo~1'), ['booers', 'boo:1'])
+      assert.equal(storage.keysReferences.get('foo~1'), undefined)
+      assert.equal(storage.keysReferences.get('foo~boo'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('boo~1'), ['booers', 'boo:1'])
     })
 
-    test('should remove a keys and references and also linked ones', async (t) => {
+    test('should remove a keys and references and also linked ones', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('a', 1, 10, ['fooers', 'vowels', 'empty'])
       storage.set('b', 1, 10, ['fooers', 'consonantes'])
@@ -441,25 +441,25 @@ test('storage memory', async (t) => {
 
       storage.invalidate(['fooers'])
 
-      t.equal(storage.get('a'), undefined)
-      t.equal(storage.get('b'), undefined)
-      t.equal(storage.get('c'), undefined)
-      t.equal(storage.get('d'), 1)
-      t.equal(storage.get('e'), 1)
+      assert.equal(storage.get('a'), undefined)
+      assert.equal(storage.get('b'), undefined)
+      assert.equal(storage.get('c'), undefined)
+      assert.equal(storage.get('d'), 1)
+      assert.equal(storage.get('e'), 1)
 
-      t.same(storage.referencesKeys.get('fooers'), undefined)
-      t.same(storage.referencesKeys.get('empty'), undefined)
-      t.same(storage.referencesKeys.get('consonantes'), ['d'])
-      t.same(storage.referencesKeys.get('vowels'), ['e'])
+      assert.deepStrictEqual(storage.referencesKeys.get('fooers'), undefined)
+      assert.deepStrictEqual(storage.referencesKeys.get('empty'), undefined)
+      assert.deepStrictEqual(storage.referencesKeys.get('consonantes'), ['d'])
+      assert.deepStrictEqual(storage.referencesKeys.get('vowels'), ['e'])
 
-      t.same(storage.keysReferences.get('a'), undefined)
-      t.same(storage.keysReferences.get('b'), undefined)
-      t.same(storage.keysReferences.get('c'), undefined)
-      t.same(storage.keysReferences.get('d'), ['consonantes'])
-      t.same(storage.keysReferences.get('e'), ['vowels'])
+      assert.deepStrictEqual(storage.keysReferences.get('a'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('b'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('c'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('d'), ['consonantes'])
+      assert.deepStrictEqual(storage.keysReferences.get('e'), ['vowels'])
     })
 
-    test('should invalidate by a string', async (t) => {
+    test('should invalidate by a string', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo~1', 'bar', 1, ['fooers', 'foo:1'])
       storage.set('foo~2', 'baz', 1, ['fooers', 'foo:2'])
@@ -467,23 +467,23 @@ test('storage memory', async (t) => {
 
       const removed = storage.invalidate('fooers')
 
-      t.same(removed, ['foo~1', 'foo~2'])
+      assert.deepStrictEqual(removed, ['foo~1', 'foo~2'])
 
-      t.equal(storage.get('foo~1'), undefined)
-      t.equal(storage.get('foo~2'), undefined)
-      t.equal(storage.get('boo~1'), 'fiz')
+      assert.equal(storage.get('foo~1'), undefined)
+      assert.equal(storage.get('foo~2'), undefined)
+      assert.equal(storage.get('boo~1'), 'fiz')
 
-      t.equal(storage.referencesKeys.get('fooers'), undefined)
-      t.equal(storage.referencesKeys.get('foo:1'), undefined)
-      t.equal(storage.referencesKeys.get('foo:2'), undefined)
-      t.same(storage.referencesKeys.get('booers'), ['boo~1'])
+      assert.equal(storage.referencesKeys.get('fooers'), undefined)
+      assert.equal(storage.referencesKeys.get('foo:1'), undefined)
+      assert.equal(storage.referencesKeys.get('foo:2'), undefined)
+      assert.deepStrictEqual(storage.referencesKeys.get('booers'), ['boo~1'])
 
-      t.equal(storage.keysReferences.get('foo~1'), undefined)
-      t.equal(storage.keysReferences.get('foo~2'), undefined)
-      t.same(storage.keysReferences.get('boo~1'), ['booers', 'boo:1'])
+      assert.equal(storage.keysReferences.get('foo~1'), undefined)
+      assert.equal(storage.keysReferences.get('foo~2'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('boo~1'), ['booers', 'boo:1'])
     })
 
-    test('should invalidate by an array of strings', async (t) => {
+    test('should invalidate by an array of strings', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo~1', 'bar', 1, ['fooers', 'foo:1'])
       storage.set('foo~2', 'baz', 1, ['fooers', 'foo:2'])
@@ -491,23 +491,23 @@ test('storage memory', async (t) => {
 
       const removed = storage.invalidate(['fooers', 'booers'])
 
-      t.same(removed, ['foo~1', 'foo~2', 'boo~1'])
+      assert.deepStrictEqual(removed, ['foo~1', 'foo~2', 'boo~1'])
 
-      t.equal(storage.get('foo~1'), undefined)
-      t.equal(storage.get('foo~2'), undefined)
-      t.equal(storage.get('boo~1'), undefined)
+      assert.equal(storage.get('foo~1'), undefined)
+      assert.equal(storage.get('foo~2'), undefined)
+      assert.equal(storage.get('boo~1'), undefined)
 
-      t.equal(storage.referencesKeys.get('fooers'), undefined)
-      t.equal(storage.referencesKeys.get('foo:1'), undefined)
-      t.equal(storage.referencesKeys.get('foo:2'), undefined)
-      t.same(storage.referencesKeys.get('booers'), undefined)
+      assert.equal(storage.referencesKeys.get('fooers'), undefined)
+      assert.equal(storage.referencesKeys.get('foo:1'), undefined)
+      assert.equal(storage.referencesKeys.get('foo:2'), undefined)
+      assert.deepStrictEqual(storage.referencesKeys.get('booers'), undefined)
 
-      t.equal(storage.keysReferences.get('foo~1'), undefined)
-      t.equal(storage.keysReferences.get('foo~2'), undefined)
-      t.same(storage.keysReferences.get('boo~1'), undefined)
+      assert.equal(storage.keysReferences.get('foo~1'), undefined)
+      assert.equal(storage.keysReferences.get('foo~2'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('boo~1'), undefined)
     })
 
-    test('should invalidate with wildcard one asterisk', async (t) => {
+    test('should invalidate with wildcard one asterisk', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo~1', 'bar', 9, ['fooers', 'foo:1'])
       storage.set('foo~2', 'baz', 9, ['fooers', 'foo:2'])
@@ -515,12 +515,12 @@ test('storage memory', async (t) => {
 
       storage.invalidate('foo:*')
 
-      t.equal(storage.get('foo~1'), undefined)
-      t.equal(storage.get('foo~2'), undefined)
-      t.equal(storage.get('boo~1'), 'fiz')
+      assert.equal(storage.get('foo~1'), undefined)
+      assert.equal(storage.get('foo~2'), undefined)
+      assert.equal(storage.get('boo~1'), 'fiz')
     })
 
-    test('should invalidate with wildcard two asterisk', async (t) => {
+    test('should invalidate with wildcard two asterisk', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo~01', '0', 1, ['group', 'foo:0x'])
       storage.set('foo~02', '0', 1, ['group', 'foo:0x'])
@@ -530,14 +530,14 @@ test('storage memory', async (t) => {
 
       storage.invalidate('f*1*')
 
-      t.equal(storage.get('foo~01'), '0')
-      t.equal(storage.get('foo~02'), '0')
-      t.equal(storage.get('foo~11'), undefined)
-      t.equal(storage.get('foo~12'), undefined)
-      t.equal(storage.get('boo~1'), 'fiz')
+      assert.equal(storage.get('foo~01'), '0')
+      assert.equal(storage.get('foo~02'), '0')
+      assert.equal(storage.get('foo~11'), undefined)
+      assert.equal(storage.get('foo~12'), undefined)
+      assert.equal(storage.get('boo~1'), 'fiz')
     })
 
-    test('should invalidate all with wildcard', async (t) => {
+    test('should invalidate all with wildcard', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('a', '0', 1, ['a', 'a:01'])
       storage.set('b', '0', 1, ['b', 'b:01'])
@@ -548,15 +548,15 @@ test('storage memory', async (t) => {
 
       storage.invalidate('*')
 
-      t.equal(storage.get('a'), undefined)
-      t.equal(storage.get('b'), undefined)
-      t.equal(storage.get('c'), undefined)
-      t.equal(storage.get('d'), undefined)
-      t.equal(storage.get('e'), undefined)
-      t.equal(storage.get('f'), undefined)
+      assert.equal(storage.get('a'), undefined)
+      assert.equal(storage.get('b'), undefined)
+      assert.equal(storage.get('c'), undefined)
+      assert.equal(storage.get('d'), undefined)
+      assert.equal(storage.get('e'), undefined)
+      assert.equal(storage.get('f'), undefined)
     })
 
-    test('should not invalidate anything with a non-existing reference', async (t) => {
+    test('should not invalidate anything with a non-existing reference', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('a', '0', 1, ['a', 'a:01'])
       storage.set('b', '0', 1, ['b', 'b:01'])
@@ -565,49 +565,49 @@ test('storage memory', async (t) => {
       storage.set('e', '0', 1, ['e', 'e:01'])
       storage.set('f', '0', 1, ['f', 'f:01'])
 
-      t.same(storage.invalidate('zzz'), [])
+      assert.deepStrictEqual(storage.invalidate('zzz'), [])
     })
 
     test('should get a warning with invalidation disabled', async (t) => {
-      t.plan(2)
+      const { equal, deepStrictEqual } = tspl(t, { plan: 2 })
 
       const storage = createStorage('memory', {
         log: {
           debug: () => { },
           warn: (error) => {
-            t.equal(error.msg, 'acd/storage/memory.invalidate, exit due invalidation is disabled')
+            equal(error.msg, 'acd/storage/memory.invalidate, exit due invalidation is disabled')
           }
         }
       })
 
-      t.same(storage.invalidate(['something']), [])
+      deepStrictEqual(storage.invalidate(['something']), [])
     })
   })
 
-  test('clear', async (t) => {
-    test('should clear the whole storage (invalidation disabled)', async (t) => {
+  describe('clear', async () => {
+    test('should clear the whole storage (invalidation disabled)', async () => {
       const storage = createStorage('memory')
       storage.set('foo', 'bar', 10)
       storage.set('baz', 'buz', 10)
 
       storage.clear()
 
-      t.equal(storage.store.size, 0)
+      assert.equal(storage.store.size, 0)
     })
 
-    test('should clear the whole storage (invalidation enabled)', async (t) => {
+    test('should clear the whole storage (invalidation enabled)', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo', 'bar', 10, ['fooers'])
       storage.set('baz', 'buz', 10, ['bazers'])
 
       storage.clear()
 
-      t.equal(storage.store.size, 0)
-      t.equal(storage.referencesKeys.size, 0)
-      t.equal(storage.keysReferences.size, 0)
+      assert.equal(storage.store.size, 0)
+      assert.equal(storage.referencesKeys.size, 0)
+      assert.equal(storage.keysReferences.size, 0)
     })
 
-    test('should clear only keys with common name', async (t) => {
+    test('should clear only keys with common name', async () => {
       const storage = createStorage('memory')
       storage.set('foo~1', 'bar', 10)
       storage.set('foo~2', 'baz', 10)
@@ -615,12 +615,12 @@ test('storage memory', async (t) => {
 
       storage.clear('foo~')
 
-      t.equal(storage.get('foo~1'), undefined)
-      t.equal(storage.get('foo~2'), undefined)
-      t.equal(storage.get('boo~1'), 'fiz')
+      assert.equal(storage.get('foo~1'), undefined)
+      assert.equal(storage.get('foo~2'), undefined)
+      assert.equal(storage.get('boo~1'), 'fiz')
     })
 
-    test('should clear a keys and their references', async (t) => {
+    test('should clear a keys and their references', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('a-a', 1, 10, ['fooers', 'vowels', 'empty'])
       storage.set('a-b', 1, 10, ['fooers', 'consonantes'])
@@ -630,42 +630,42 @@ test('storage memory', async (t) => {
 
       storage.clear('a-')
 
-      t.equal(storage.get('a-a'), undefined)
-      t.equal(storage.get('a-b'), undefined)
-      t.equal(storage.get('a-c'), undefined)
-      t.equal(storage.get('b-d'), 1)
-      t.equal(storage.get('b-e'), 1)
+      assert.equal(storage.get('a-a'), undefined)
+      assert.equal(storage.get('a-b'), undefined)
+      assert.equal(storage.get('a-c'), undefined)
+      assert.equal(storage.get('b-d'), 1)
+      assert.equal(storage.get('b-e'), 1)
 
-      t.same(storage.referencesKeys.get('fooers'), undefined)
-      t.same(storage.referencesKeys.get('empty'), undefined)
-      t.same(storage.referencesKeys.get('consonantes'), ['b-d'])
-      t.same(storage.referencesKeys.get('vowels'), ['b-e'])
+      assert.deepStrictEqual(storage.referencesKeys.get('fooers'), undefined)
+      assert.deepStrictEqual(storage.referencesKeys.get('empty'), undefined)
+      assert.deepStrictEqual(storage.referencesKeys.get('consonantes'), ['b-d'])
+      assert.deepStrictEqual(storage.referencesKeys.get('vowels'), ['b-e'])
 
-      t.same(storage.keysReferences.get('a-a'), undefined)
-      t.same(storage.keysReferences.get('a-b'), undefined)
-      t.same(storage.keysReferences.get('a-c'), undefined)
-      t.same(storage.keysReferences.get('b-d'), ['consonantes'])
-      t.same(storage.keysReferences.get('b-e'), ['vowels'])
+      assert.deepStrictEqual(storage.keysReferences.get('a-a'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('a-b'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('a-c'), undefined)
+      assert.deepStrictEqual(storage.keysReferences.get('b-d'), ['consonantes'])
+      assert.deepStrictEqual(storage.keysReferences.get('b-e'), ['vowels'])
     })
   })
 
-  test('refresh', async (t) => {
-    test('should start a new storage', async (t) => {
+  describe('refresh', async () => {
+    test('should start a new storage', async () => {
       const storage = createStorage('memory')
       storage.set('foo', 'bar', 10)
 
       storage.refresh()
-      t.equal(storage.store.size, 0)
+      assert.equal(storage.store.size, 0)
     })
 
-    test('should start a new storage (invalidation enabled)', async (t) => {
+    test('should start a new storage (invalidation enabled)', async () => {
       const storage = createStorage('memory', { invalidation: true })
       storage.set('foo', 'bar', 10, ['fooers'])
 
       storage.refresh()
-      t.equal(storage.store.size, 0)
-      t.equal(storage.referencesKeys.size, 0)
-      t.equal(storage.referencesKeys.size, 0)
+      assert.equal(storage.store.size, 0)
+      assert.equal(storage.referencesKeys.size, 0)
+      assert.equal(storage.referencesKeys.size, 0)
     })
   })
 })

--- a/test/storage-redis.test.js
+++ b/test/storage-redis.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, describe, beforeEach, after } = require('node:test')
+const { test, describe, before, beforeEach, after } = require('node:test')
 const assert = require('node:assert')
 const { tspl } = require('@matteo.collina/tspl')
 const { promisify } = require('util')
@@ -25,7 +25,7 @@ function assertInclude (t, array0, array1) {
 }
 
 describe('storage redis', async () => {
-  beforeEach(async () => {
+  before(async () => {
     await redisClient.flushall()
   })
 

--- a/test/transformer.test.js
+++ b/test/transformer.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { test, describe, after } = require('node:test')
+const { test, describe, after, before } = require('node:test')
 const assert = require('assert')
 const Redis = require('ioredis')
 
 const createStorage = require('../src/storage')
 const { Cache } = require('../')
 
-let redisClient;
+let redisClient
 
 describe('transformer', async function () {
   before(async () => {

--- a/test/transformer.test.js
+++ b/test/transformer.test.js
@@ -7,9 +7,13 @@ const Redis = require('ioredis')
 const createStorage = require('../src/storage')
 const { Cache } = require('../')
 
-const redisClient = new Redis()
+let redisClient;
 
-describe('transformer', function () {
+describe('transformer', async function () {
+  before(async () => {
+    redisClient = new Redis()
+  })
+
   after(async () => {
     await redisClient.quit()
   })

--- a/test/transformer.test.js
+++ b/test/transformer.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { test, before, teardown } = require('tap')
+const { test, before, after } = require('node:test')
+const assert = require('assert')
 const Redis = require('ioredis')
 
 const createStorage = require('../src/storage')
@@ -11,7 +12,7 @@ before(async (t) => {
   redisClient = new Redis()
 })
 
-teardown(async (t) => {
+after(async (t) => {
   await redisClient.quit()
 })
 
@@ -21,11 +22,11 @@ test('should handle a custom transformer to store and get data per cache', async
     storage: createStorage(),
     transformer: {
       serialize: (value) => {
-        t.pass('serialize called')
+        assert.ok('serialize called')
         return JSON.stringify(value)
       },
       deserialize: (value) => {
-        t.pass('deserialize called')
+        assert.ok('deserialize called')
         return JSON.parse(value)
       }
     }
@@ -35,8 +36,8 @@ test('should handle a custom transformer to store and get data per cache', async
     return { k: query }
   })
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 })
 
 test('should handle a custom transformer to store and get data per define', async function (t) {
@@ -48,11 +49,11 @@ test('should handle a custom transformer to store and get data per define', asyn
     ttl: 1000,
     transformer: {
       serialize: (value) => {
-        t.pass('serialize called')
+        assert.ok('serialize called')
         return JSON.stringify(value)
       },
       deserialize: (value) => {
-        t.pass('deserialize called')
+        assert.ok('deserialize called')
         return JSON.parse(value)
       }
     }
@@ -60,8 +61,8 @@ test('should handle a custom transformer to store and get data per define', asyn
     return { k: query }
   })
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 })
 
 test('should handle a custom transformer and references function to store and get data per cache', async function (t) {
@@ -70,11 +71,11 @@ test('should handle a custom transformer and references function to store and ge
     storage: createStorage(),
     transformer: {
       serialize: (value) => {
-        t.pass('serialize called')
+        assert.ok('serialize called')
         return JSON.stringify(value)
       },
       deserialize: (value) => {
-        t.pass('deserialize called')
+        assert.ok('deserialize called')
         return JSON.parse(value)
       }
     }
@@ -82,15 +83,15 @@ test('should handle a custom transformer and references function to store and ge
 
   cache.define('fetchSomething', {
     references: (args, key, result) => {
-      t.pass('references called')
+      assert.ok('references called')
       return ['some-reference']
     }
   }, async (query, cacheKey) => {
     return { k: query }
   })
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 })
 
 test('should handle a custom transformer and references function to store and get data per define', async function (t) {
@@ -101,16 +102,16 @@ test('should handle a custom transformer and references function to store and ge
   cache.define('fetchSomething', {
     ttl: 1000,
     references: (args, key, result) => {
-      t.pass('references called')
+      assert.ok('references called')
       return ['some-reference']
     },
     transformer: {
       serialize: (value) => {
-        t.pass('serialize called')
+        assert.ok('serialize called')
         return JSON.stringify(value)
       },
       deserialize: (value) => {
-        t.pass('deserialize called')
+        assert.ok('deserialize called')
         return JSON.parse(value)
       }
     }
@@ -118,6 +119,6 @@ test('should handle a custom transformer and references function to store and ge
     return { k: query }
   })
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 })

--- a/test/transformer.test.js
+++ b/test/transformer.test.js
@@ -1,124 +1,123 @@
 'use strict'
 
-const { test, before, after } = require('node:test')
+const { test, describe, after } = require('node:test')
 const assert = require('assert')
 const Redis = require('ioredis')
 
 const createStorage = require('../src/storage')
 const { Cache } = require('../')
 
-let redisClient
-before(async (t) => {
-  redisClient = new Redis()
-})
+const redisClient = new Redis()
 
-after(async (t) => {
-  await redisClient.quit()
-})
+describe('transformer', function () {
+  after(async () => {
+    await redisClient.quit()
+  })
 
-test('should handle a custom transformer to store and get data per cache', async function (t) {
-  const cache = new Cache({
-    ttl: 1000,
-    storage: createStorage(),
-    transformer: {
-      serialize: (value) => {
-        assert.ok('serialize called')
-        return JSON.stringify(value)
-      },
-      deserialize: (value) => {
-        assert.ok('deserialize called')
-        return JSON.parse(value)
+  test('should handle a custom transformer to store and get data per cache', async function (t) {
+    const cache = new Cache({
+      ttl: 1000,
+      storage: createStorage(),
+      transformer: {
+        serialize: (value) => {
+          assert.ok('serialize called')
+          return JSON.stringify(value)
+        },
+        deserialize: (value) => {
+          assert.ok('deserialize called')
+          return JSON.parse(value)
+        }
       }
-    }
+    })
+
+    cache.define('fetchSomething', async (query, cacheKey) => {
+      return { k: query }
+    })
+
+    assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+    assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
   })
 
-  cache.define('fetchSomething', async (query, cacheKey) => {
-    return { k: query }
-  })
+  test('should handle a custom transformer to store and get data per define', async function (t) {
+    const cache = new Cache({
+      storage: createStorage()
+    })
 
-  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
-  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
-})
-
-test('should handle a custom transformer to store and get data per define', async function (t) {
-  const cache = new Cache({
-    storage: createStorage()
-  })
-
-  cache.define('fetchSomething', {
-    ttl: 1000,
-    transformer: {
-      serialize: (value) => {
-        assert.ok('serialize called')
-        return JSON.stringify(value)
-      },
-      deserialize: (value) => {
-        assert.ok('deserialize called')
-        return JSON.parse(value)
+    cache.define('fetchSomething', {
+      ttl: 1000,
+      transformer: {
+        serialize: (value) => {
+          assert.ok('serialize called')
+          return JSON.stringify(value)
+        },
+        deserialize: (value) => {
+          assert.ok('deserialize called')
+          return JSON.parse(value)
+        }
       }
-    }
-  }, async (query, cacheKey) => {
-    return { k: query }
+    }, async (query, cacheKey) => {
+      return { k: query }
+    })
+
+    assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+    assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
   })
 
-  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
-  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
-})
-
-test('should handle a custom transformer and references function to store and get data per cache', async function (t) {
-  const cache = new Cache({
-    ttl: 1000,
-    storage: createStorage(),
-    transformer: {
-      serialize: (value) => {
-        assert.ok('serialize called')
-        return JSON.stringify(value)
-      },
-      deserialize: (value) => {
-        assert.ok('deserialize called')
-        return JSON.parse(value)
+  test('should handle a custom transformer and references function to store and get data per cache', async function (t) {
+    const cache = new Cache({
+      ttl: 1000,
+      storage: createStorage(),
+      transformer: {
+        serialize: (value) => {
+          assert.ok('serialize called')
+          return JSON.stringify(value)
+        },
+        deserialize: (value) => {
+          assert.ok('deserialize called')
+          return JSON.parse(value)
+        }
       }
-    }
-  })
+    })
 
-  cache.define('fetchSomething', {
-    references: (args, key, result) => {
-      assert.ok('references called')
-      return ['some-reference']
-    }
-  }, async (query, cacheKey) => {
-    return { k: query }
-  })
-
-  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
-  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
-})
-
-test('should handle a custom transformer and references function to store and get data per define', async function (t) {
-  const cache = new Cache({
-    storage: createStorage()
-  })
-
-  cache.define('fetchSomething', {
-    ttl: 1000,
-    references: (args, key, result) => {
-      assert.ok('references called')
-      return ['some-reference']
-    },
-    transformer: {
-      serialize: (value) => {
-        assert.ok('serialize called')
-        return JSON.stringify(value)
-      },
-      deserialize: (value) => {
-        assert.ok('deserialize called')
-        return JSON.parse(value)
+    cache.define('fetchSomething', {
+      references: (args, key, result) => {
+        assert.ok('references called')
+        return ['some-reference']
       }
-    }
-  }, async (query, cacheKey) => {
-    return { k: query }
+    }, async (query, cacheKey) => {
+      return { k: query }
+    })
+
+    assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+    assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
   })
 
-  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
-  assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  test('should handle a custom transformer and references function to store and get data per define', async function (t) {
+    const cache = new Cache({
+      storage: createStorage()
+    })
+
+    cache.define('fetchSomething', {
+      ttl: 1000,
+      references: (args, key, result) => {
+        assert.ok('references called')
+        return ['some-reference']
+      },
+      transformer: {
+        serialize: (value) => {
+          assert.ok('serialize called')
+          return JSON.stringify(value)
+        },
+        deserialize: (value) => {
+          assert.ok('deserialize called')
+          return JSON.parse(value)
+        }
+      }
+    }, async (query, cacheKey) => {
+      return { k: query }
+    })
+
+    assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+    assert.deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  })
 })

--- a/test/transformer.test.js
+++ b/test/transformer.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { test, describe, after } = require('node:test')
+const { test, describe, after, before } = require('node:test')
 const assert = require('assert')
 const Redis = require('ioredis')
 
 const createStorage = require('../src/storage')
 const { Cache } = require('../')
 
-const redisClient = new Redis()
+let redisClient
 
 describe('transformer', async function () {
   before(async () => {

--- a/test/transformer.test.js
+++ b/test/transformer.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { test, describe, after, before } = require('node:test')
+const { test, describe, after } = require('node:test')
 const assert = require('assert')
 const Redis = require('ioredis')
 
 const createStorage = require('../src/storage')
 const { Cache } = require('../')
 
-let redisClient
+const redisClient = new Redis()
 
 describe('transformer', async function () {
   before(async () => {

--- a/test/ttl.test.js
+++ b/test/ttl.test.js
@@ -1,18 +1,15 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
+const { tspl } = require('@matteo.collina/tspl')
 const { promisify } = require('util')
 const { Cache } = require('../src/cache')
 const createStorage = require('../src/storage')
 
 const sleep = promisify(setTimeout)
 
-const { test } = t
-
-t.jobs = 3
-
 test('ttl', async (t) => {
-  t.plan(5)
+  const { equal, deepStrictEqual } = tspl(t, { plan: 5 })
 
   const cache = new Cache({
     storage: createStorage(),
@@ -20,42 +17,42 @@ test('ttl', async (t) => {
   })
 
   cache.define('fetchSomething', async (query) => {
-    t.equal(query, 42)
+    equal(query, 42)
     return { k: query }
   })
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 
   await sleep(2500)
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 })
 
 test('global ttl is a positive integer', async (t) => {
-  t.plan(1)
+  const { equal } = tspl(t, { plan: 1 })
 
   try {
     // eslint-disable-next-line no-new
     new Cache({ ttl: 3.14, storage: createStorage() })
   } catch (err) {
-    t.equal(err.message, 'ttl must be a positive integer greater than 0')
+    equal(err.message, 'ttl must be a positive integer greater than 0')
   }
 })
 
 test('function ttl is a positive integer', async (t) => {
-  t.plan(1)
+  const { equal } = tspl(t, { plan: 1 })
 
   const cache = new Cache({ storage: createStorage() })
   try {
     cache.define('fetchSomething', { ttl: 3.14 }, async (k) => ({ k }))
   } catch (err) {
-    t.equal(err.message, 'ttl must be a positive integer greater than 0')
+    equal(err.message, 'ttl must be a positive integer greater than 0')
   }
 })
 
 test('ttl expires', async (t) => {
-  t.plan(5)
+  const { equal, deepStrictEqual } = tspl(t, { plan: 5 })
 
   const cache = new Cache({
     storage: createStorage(),
@@ -63,29 +60,29 @@ test('ttl expires', async (t) => {
   })
 
   cache.define('fetchSomething', async (query) => {
-    t.equal(query, 42)
+    equal(query, 42)
     return { k: query }
   })
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 
   await sleep(1000)
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 
   await sleep(3000)
 
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 })
 
 test('do not cache failures', async (t) => {
-  t.plan(4)
+  const { ok, deepStrictEqual, rejects } = tspl(t, { plan: 4 })
 
   const cache = new Cache({ ttl: 42, storage: createStorage() })
 
   let called = false
   cache.define('fetchSomething', async (query) => {
-    t.pass('called')
+    ok('called')
     if (!called) {
       called = true
       throw new Error('kaboom')
@@ -93,12 +90,12 @@ test('do not cache failures', async (t) => {
     return { k: query }
   })
 
-  await t.rejects(cache.fetchSomething(42))
-  t.same(await cache.fetchSomething(42), { k: 42 })
+  await rejects(cache.fetchSomething(42))
+  deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 })
 
 test('function ttl has precedence over global ttl', async (t) => {
-  t.plan(1)
+  const { equal } = tspl(t, { plan: 1 })
 
   const cache = new Cache({ ttl: 42, storage: createStorage() })
 
@@ -111,11 +108,11 @@ test('function ttl has precedence over global ttl', async (t) => {
   await cache.fetchSomething(42)
   await cache.fetchSomething(42)
 
-  t.same(callCount, 2)
+  equal(callCount, 2)
 })
 
 test('ttl as a function', async (t) => {
-  t.plan(2)
+  const { equal } = tspl(t, { plan: 2 })
 
   const cache = new Cache({ storage: createStorage() })
 
@@ -128,9 +125,9 @@ test('ttl as a function', async (t) => {
   await cache.fetchSomething(42)
   await cache.fetchSomething(42)
   await cache.fetchSomething(42)
-  t.same(callCount, 1)
+  equal(callCount, 1)
 
   await sleep(3000)
   await cache.fetchSomething(42)
-  t.same(callCount, 2)
+  equal(callCount, 2)
 })

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const assert = require('node:assert')
 const { bsearchIndex, randomSubset, wildcardMatch } = require('../src/util')
 
 test('bsearchIndex', async t => {
@@ -17,7 +18,7 @@ test('bsearchIndex', async t => {
 
   for (const case_ of cases) {
     const result = bsearchIndex(...case_.input)
-    t.equal(result, case_.output)
+    assert.equal(result, case_.output)
   }
 })
 
@@ -32,8 +33,8 @@ test('randomSubset', async t => {
 
   for (const case_ of cases) {
     const result = randomSubset(case_.array, case_.size)
-    t.ok(result.length > 0)
-    t.ok(result.length <= case_.size)
+    assert.ok(result.length > 0)
+    assert.ok(result.length <= case_.size)
   }
 
   cases = [
@@ -43,7 +44,7 @@ test('randomSubset', async t => {
 
   for (const case_ of cases) {
     const result = randomSubset(case_.array, case_.size)
-    t.equal(result.length, case_.resultLength)
+    assert.equal(result.length, case_.resultLength)
   }
 })
 
@@ -67,6 +68,6 @@ test('wildcardMatch', async t => {
   ]
 
   for (const case_ of cases) {
-    t.equal(wildcardMatch(case_.value, case_.content), case_.result, `${case_.value} ${case_.content} => ${case_.result}`)
+    assert.equal(wildcardMatch(case_.value, case_.content), case_.result, `${case_.value} ${case_.content} => ${case_.result}`)
   }
 })


### PR DESCRIPTION
This PR aims to resolve #98 by migrating the whole codebase of tests that runs server side using the Node Test Runners

- [x] `test/base.test.js`
- [x] `test/cache.test.js`
- [x] `test/clear.test.js`
- [x] `test/stale.test.js`
- [x] `test/storage-base.test.js`
- [x] `test/storage-memory.test.js`
- [x] `test/storage-redis.test.js`
- [x] `test/transformer.test.js`
- [x] `test/ttl.test.js`
- [x] `test/utils.test.js`

I used `tspl` where required by previous tests. Otherwise I kept the default Node assertions.

We need to figure out possibly whether to normalize all assertions under `tspl` or proceed to use only if we are going to ensure assertion count.
