### PR TITLE
Custom storage implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,42 @@ setInterval(() => {
 
 ```
 
+### Custom storage
+
+Allow users to provide their own storage implementation that conforms to the expected async interface. 
+
+```js
+const { StorageInterface } = require('async-cache-dedupe')
+
+class CustomStorage extends StorageInterface {
+  async get (key) { } // Retrieve value from your storage
+  async set (key, value, ttl, references) { } // Store value in your storage with TTL and references
+  async remove (key) { } // Remove value by key
+  async invalidate (references) { } // Invalidate all entries with given references
+  async clear () { } // Clear entire cache
+  async refresh () { } // Used internally for TTL refresh logic
+  async getTTL (key) { // Return TTL for a key}
+}
+
+const { createStorage, Cache } = require('async-cache-dedupe')
+
+const storage = createStorage('custom', {
+  storage: new CustomStorage({
+    // You can set the optiions required for the custom storage
+  })
+})
+
+const cache = createCache({
+  ttl: 5,
+  storage: { type: 'custom', options: { storage } },
+})
+```
+
+- When using the `custom` storage type, you must provide a valid storage instance via the options.
+- You can refer to the [Redis](https://github.com/mcollina/async-cache-dedupe/blob/main/src/storage/redis.js) or [Memory](https://github.com/mcollina/async-cache-dedupe/blob/main/src/storage/memory.js) storage implementation for guidance.
+- Ensure your storage implementation is compatible with your runtime environment (server or client).
+
+
 ---
 
 ## TypeScript

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const { Cache } = require('./src/cache')
 const createStorage = require('./src/storage')
+const StorageInterface = require('./src/storage/interface')
 
 /**
    * @param {!Object} options
@@ -25,5 +26,6 @@ function createCache (options) {
 module.exports = {
   Cache,
   createCache,
-  createStorage
+  createStorage,
+  StorageInterface
 }

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -17,8 +17,14 @@ const StorageMemory = require('./memory')
  */
 const StorageOptionsType = {
   redis: 'redis',
-  memory: 'memory'
+  memory: 'memory',
+  custom: 'custom'
 }
+
+/**
+ * @typedef StorageCustomOptions
+ * @property {StorageInterface} storage
+ */
 
 /**
  * @typedef {Object} StorageOptions
@@ -28,12 +34,20 @@ const StorageOptionsType = {
 /**
  * factory for storage, depending on type
  * @param {StorageOptionsType} type
- * @param {StorageMemoryOptions|StorageRedisOptions} options
+ * @param {StorageMemoryOptions|StorageRedisOptions|StorageCustomOptions} options
  * @returns {StorageMemory|StorageRedis}
  */
 function createStorage (type, options) {
   if (!isServerSide && type === StorageOptionsType.redis) {
     throw new Error('Redis storage is not supported in the browser')
+  }
+
+  if (type === 'custom') {
+    if (!options.storage) {
+      throw new Error('Storage is required for custom storage type')
+    }
+
+    return options.storage
   }
 
   if (type === StorageOptionsType.redis) {

--- a/test/storage-custom.test.js
+++ b/test/storage-custom.test.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const { test, describe } = require('node:test')
+const assert = require('node:assert')
+const proxyquire = require('proxyquire')
+const createStorage = require('../src/storage')
+
+const dummyStorage = {
+  async get (key) { },
+  async set (key, value, ttl, references) { },
+  async remove (key) { },
+  async invalidate (references) { },
+  async clear () { },
+  async refresh () { },
+  async getTTL () { }
+}
+
+describe('storage custom', async () => {
+  test('should get an instance with default options', async () => {
+    const storage = createStorage('custom', { storage: dummyStorage })
+
+    assert.ok(typeof storage.get === 'function')
+    assert.ok(typeof storage.set === 'function')
+    assert.ok(typeof storage.remove === 'function')
+    assert.ok(typeof storage.invalidate === 'function')
+    assert.ok(typeof storage.refresh === 'function')
+    assert.ok(typeof storage.getTTL === 'function')
+  })
+
+  test('should throw if is not server side and storage is redis', async (t) => {
+    const createStorage = proxyquire('../src/storage/index.js', {
+      '../util': { isServerSide: false }
+    })
+
+    assert.throws(() => createStorage('custom', { }), {
+      message: 'Storage is required for custom storage type'
+    })
+  })
+})


### PR DESCRIPTION
### Summary

This PR adds support for a custom storage type in async-cache-dedupe, allowing users to provide their own storage implementation by extending StorageInterface.

### Changes
- Added support for custom type in createStorage
- Introduced validation to ensure a storage instance is provided
- Added unit tests for custom storage behavior
- Updated README.md with usage example and guidelines