### PR TITLE
ci: skip browsers workflow for dependabot, bump action versions

### DIFF
--- a/.github/workflows/browsers-ci.yml
+++ b/.github/workflows/browsers-ci.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -26,15 +27,15 @@ jobs:
           - os: windows-latest
             browser: safari
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Restore cached playwright dependency
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: playwright-cache
         with:
           path: | # playwright installs browsers into .local-browsers
@@ -44,7 +45,7 @@ jobs:
           key: ${{ matrix.os }}-playwright-${{ hashFiles('package.json') }}
 
       - name: Restore cached dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ matrix.os }}-${{ hashFiles('package.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
         - 6379:6379
         options: --entrypoint redis-server
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## Summary
- Skip the 50-job `browsers-ci` matrix on dependabot pushes/PRs (`if: github.actor != 'dependabot[bot]'`) — this was the bulk of Actions cache and data-transfer usage on the repo, since every dependabot bump triggered playwright browser downloads across 3 OSes × 4 browsers × 5 bundlers.
- Bump `actions/checkout`, `actions/setup-node`, and `actions/cache` to `v4` in both workflows.
- Bump the browsers job's Node.js to `22` (was `18`, EOL).

## Test plan
- [ ] CI runs on this PR and the browsers matrix executes (non-dependabot actor).
- [ ] Confirm a follow-up dependabot PR skips the `build` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)