### PR TITLE
feat: use `object-identity` a faster/smaller object canon

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Options:
 Define a new function to cache of the given `name`.
 
 The `define` method adds a `cache[name]` function that will call the `original` function if the result is not present
-in the cache. The cache key for `arg` is computed using [`safe-stable-stringify`](https://www.npmjs.com/package/safe-stable-stringify) and it is passed as the `cacheKey` argument to the original function.
+in the cache. The cache key for `arg` is computed using [`object-identity`](https://www.npmjs.com/package/object-identity) and it is passed as the `cacheKey` argument to the original function.
 
 Options:
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
   },
   "dependencies": {
     "mnemonist": "^0.40.3",
-    "safe-stable-stringify": "^2.5.0"
+    "object-identity": "^0.2.2"
   }
 }

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { kValues, kStorage, kStorages, kTransfromer, kTTL, kOnDedupe, kOnError, kOnHit, kOnMiss, kStale } = require('./symbol')
-const stringify = require('safe-stable-stringify')
+const { identify } = require('object-identity')
 const createStorage = require('./storage')
 
 class Cache {
@@ -228,7 +228,7 @@ class Wrapper {
 
   getKey (args) {
     const id = this.serialize ? this.serialize(args) : args
-    return typeof id === 'string' ? id : stringify(id)
+    return typeof id === 'string' ? id : identify(id)
   }
 
   getStorageKey (key) {

--- a/src/storage/redis.js
+++ b/src/storage/redis.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { identify } = require('object-identity')
 const StorageInterface = require('./interface')
 const { findNotMatching, randomSubset, abstractLogging } = require('../util')
 
@@ -132,7 +131,7 @@ class StorageRedis extends StorageInterface {
     }
 
     try {
-      await this.store.set(key, identify(value), 'EX', ttl)
+      await this.store.set(key, JSON.stringify(value), 'EX', ttl)
 
       if (!references || references.length < 1) {
         return

--- a/src/storage/redis.js
+++ b/src/storage/redis.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const stringify = require('safe-stable-stringify')
+const { identify } = require('object-identity')
 const StorageInterface = require('./interface')
 const { findNotMatching, randomSubset, abstractLogging } = require('../util')
 
@@ -132,7 +132,7 @@ class StorageRedis extends StorageInterface {
     }
 
     try {
-      await this.store.set(key, stringify(value), 'EX', ttl)
+      await this.store.set(key, identify(value), 'EX', ttl)
 
       if (!references || references.length < 1) {
         return

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -4,7 +4,7 @@ const { describe, test, before, after } = require('node:test')
 const assert = require('node:assert')
 const { tspl } = require('@matteo.collina/tspl')
 const Redis = require('ioredis')
-const stringify = require('safe-stable-stringify')
+const { identify } = require('object-identity')
 
 const { kValues, kStorage } = require('../src/symbol')
 const createStorage = require('../src/storage')
@@ -45,7 +45,7 @@ describe('base', async () => {
 
     cache.define('fetchSomething', async (value, key) => {
       equal(value, expected.shift())
-      equal(stringify(value), key)
+      equal(identify(value), key)
       return { k: value }
     })
 
@@ -266,7 +266,7 @@ describe('base', async () => {
 
     cache.define('fetchSomething', async (query, cacheKey) => {
       deepStrictEqual(query, expected.shift())
-      equal(stringify(query), cacheKey)
+      equal(identify(query), cacheKey)
 
       return { k: query }
     })
@@ -564,7 +564,7 @@ describe('base', async () => {
 
     cache.define('fetchSomething', async (query, cacheKey) => {
       deepStrictEqual(query, expected.shift())
-      equal(stringify(query), cacheKey)
+      equal(identify(query), cacheKey)
       return { k: query }
     })
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -169,7 +169,7 @@ describe('base', async () => {
     const p1 = cache.fetchSomething({ k: 42 })
     const p2 = cache.fetchSomething({ k: 24 })
 
-    deepStrictEqual([...cache[kValues].fetchSomething.dedupes.keys()], ['42', '24'])
+    deepStrictEqual([...cache[kValues].fetchSomething.dedupes.keys()], ['n42', 'n24'])
     const res = await Promise.all([p1, p2])
 
     deepStrictEqual(res, [

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -29,21 +29,21 @@ test('stale', async (t) => {
   deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
   deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
 
-  equal(storage.getTTL('fetchSomething~42'), 10)
+  equal(storage.getTTL('fetchSomething~n42'), 10)
   await sleep(2500)
-  equal(storage.getTTL('fetchSomething~42') < 10, true)
+  equal(storage.getTTL('fetchSomething~n42') < 10, true)
 
   // This value will be revalidated
   toReturn++
   deepStrictEqual(await cache.fetchSomething(42), { k: 42 })
-  equal(storage.getTTL('fetchSomething~42'), 10)
+  equal(storage.getTTL('fetchSomething~n42'), 10)
 
   await sleep(500)
 
   deepStrictEqual(await cache.fetchSomething(42), { k: 43 })
 
   deepStrictEqual(await cache.fetchSomething(42), { k: 43 })
-  equal(storage.getTTL('fetchSomething~42'), 10)
+  equal(storage.getTTL('fetchSomething~n42'), 10)
 })
 
 test('global stale is a positive integer', async (t) => {
@@ -103,21 +103,21 @@ test('stale as a function', async (t) => {
   deepStrictEqual(await cache.fetchSomething(42), { k: 42, stale: 9 })
   deepStrictEqual(await cache.fetchSomething(42), { k: 42, stale: 9 })
 
-  equal(storage.getTTL('fetchSomething~42'), 10)
+  equal(storage.getTTL('fetchSomething~n42'), 10)
   await sleep(2500)
-  equal(storage.getTTL('fetchSomething~42') < 10, true)
+  equal(storage.getTTL('fetchSomething~n42') < 10, true)
 
   // This value will be revalidated
   toReturn++
   deepStrictEqual(await cache.fetchSomething(42), { k: 42, stale: 9 })
-  equal(storage.getTTL('fetchSomething~42'), 10)
+  equal(storage.getTTL('fetchSomething~n42'), 10)
 
   await sleep(500)
 
   deepStrictEqual(await cache.fetchSomething(42), { k: 43, stale: 9 })
 
   deepStrictEqual(await cache.fetchSomething(42), { k: 43, stale: 9 })
-  equal(storage.getTTL('fetchSomething~42'), 10)
+  equal(storage.getTTL('fetchSomething~n42'), 10)
 })
 
 test('stale as a function parameter', async (t) => {


### PR DESCRIPTION
Hey! 👋 [`object-identity`](https://github.com/maraisr/object-identity) author here.

I'm a fan of `async-cache-dedupe` (actually wrote a [very similar library](https://github.com/maraisr/swrr/tree/cloudflare-cache-support) a long time ago, but abandoned it, this was better). I've been putting a [fair](https://github.com/maraisr/object-identity/commit/709e297595ed5a61e0751f9dbbd7a8e81001062e) [bit](https://github.com/maraisr/object-identity/commit/c2bddd38a3ce20277006f1c07db943758d1ec3f9) [of](https://github.com/maraisr/object-identity/commit/9842e2ed2c38cca8618dbafec909c6ddf2048808) [work](https://github.com/maraisr/object-identity/commit/e4ea2ad776fecc81ab7fb8bae086f2ffa7229557) into `object-identity` lately, and I think it's worth an adoption here.

I am reaching out because `object-identity` runs around ~1.5x faster on these shapes ([benchmarks](https://github.com/maraisr/object-identity#-benchmark)) and is much, much smaller, roughly 530B gzipped against about 3KB for `safe-stable-stringify` with zero dependencies, so it could be a cheap win for everyone.

Worth flagging though that it does change the cache key, so this would technically be a breaking change. Totally your call, and no worries at all if you'd rather leave things as they are.

I also noticed you've contributed to `safe-stable-stringify` before, which is really cool to see. If you're ever interested in collaborating or bouncing ideas around this space, I'd genuinely love to chat.

Either way, thanks for building such a great library.