### PR TITLE
feat(cache): add getSync to retrieve cached values synchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,42 @@ Options:
   await cache.fetchUserProfile()
   ```
 
+### `cache.get(name, key)`
+
+Returns the value stored in the cache for the given `name` and `key`. Always returns a `Promise`. On a cache miss, the value is computed by calling the underlying function and stored in the cache (subject to the configured `ttl`).
+
+### `cache.getSync(name, key)`
+
+Synchronous variant of `cache.get`. Returns the cached value directly when the underlying storage can answer synchronously (currently only `memory`), and returns `undefined` otherwise. Use this on hot paths where you have already populated the cache and want to avoid the extra event loop tick introduced by `Promise` wrapping.
+
+`getSync` returns `undefined` if:
+
+* the key is not in the cache (miss)
+* the entry is expired
+* the configured storage is asynchronous (e.g. `redis`)
+* a `transformer` is configured with an async `deserialize`
+
+The `name` must be defined via `cache.define`, otherwise an `Error` is thrown (same behavior as `cache.get`).
+
+The `key` is the same key the wrapped function receives, without the internal `${name}~` storage prefix.
+
+Example:
+
+```js
+const cache = createCache({ ttl: 60, storage: { type: 'memory' } })
+cache.define('fetchSomething', async (k) => ({ k }))
+
+await cache.fetchSomething('42')     // populate the cache
+
+const value = cache.getSync('fetchSomething', '42')
+if (value === undefined) {
+  // not cached, or storage is async — fall back to the async path
+  const v = await cache.fetchSomething('42')
+} else {
+  // use `value` directly, no `await` needed
+}
+```
+
 ### `cache.clear([name], [arg])`
 
 Clear the cache. If `name` is specified, all the cache entries from the function defined with that name are cleared.

--- a/README.md
+++ b/README.md
@@ -182,13 +182,13 @@ Returns the value stored in the cache for the given `name` and `key`. Always ret
 
 ### `cache.getSync(name, key)`
 
-Synchronous variant of `cache.get`. Returns the cached value directly when the underlying storage can answer synchronously (currently only `memory`), and returns `undefined` otherwise. Use this on hot paths where you have already populated the cache and want to avoid the extra event loop tick introduced by `Promise` wrapping.
+Synchronous variant of `cache.get`. Returns the cached value directly when the underlying storage can answer synchronously (the in-process `memory` storage), and returns `undefined` otherwise. Use this on hot paths where you have already populated the cache and want to avoid the extra event loop tick introduced by `Promise` wrapping.
 
 `getSync` returns `undefined` if:
 
 * the key is not in the cache (miss)
 * the entry is expired
-* the configured storage is asynchronous (e.g. `redis`)
+* the configured storage is asynchronous (e.g. `redis` without `syncCache`)
 * a `transformer` is configured with an async `deserialize`
 
 The `name` must be defined via `cache.define`, otherwise an `Error` is thrown (same behavior as `cache.get`).
@@ -211,6 +211,33 @@ if (value === undefined) {
   // use `value` directly, no `await` needed
 }
 ```
+
+### `syncCache` option (opt-in)
+
+`getSync` is most useful with the in-process `memory` storage. For Redis-backed caches (and any other async storage), you can opt in to a small, bounded-staleness secondary cache that backs `getSync`:
+
+```js
+const cache = createCache({
+  ttl: 60,
+  storage: { type: 'redis', options: { client } },
+  syncCache: { size: 1024, ttl: 1000 } // 1s staleness budget, 1024 entries
+})
+```
+
+When `syncCache` is configured, every successful async fetch populates an in-process LRU. `getSync` reads the LRU directly. The trade-off is explicit: a `getSync` hit may return data up to `syncCache.ttl` milliseconds old, even if Redis has newer data. Pick the staleness budget that fits your freshness requirements.
+
+The `syncCache` option can also be set per defined function, overriding the cache-level setting:
+
+```js
+cache.define('hotPath', {
+  ttl: 60,
+  syncCache: { size: 100, ttl: 500 }   // tighter staleness for this entry only
+}, async (k) => ({ k }))
+```
+
+Without `syncCache`, `getSync` falls through to the underlying storage's `getSync`. For Redis, that returns `undefined` (Redis is async). For `memory`, it reads the storage's LRU directly with no staleness bound.
+
+The sync LRU is invalidated when `cache.invalidate` (by references) or `cache.clear` is called, so callers don't see stale data after explicit invalidations. `cache.set(name, key, value, …)` removes the corresponding sync LRU entry but does not repopulate it — the next `getSync` will miss until either the wrapped function runs again or an async fetch reads it back.
 
 ### `cache.clear([name], [arg])`
 

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,8 +1,9 @@
 'use strict'
 
-const { kValues, kStorage, kStorages, kTransfromer, kTTL, kOnDedupe, kOnError, kOnHit, kOnMiss, kStale } = require('./symbol')
+const { kValues, kStorage, kStorages, kTransfromer, kTTL, kOnDedupe, kOnError, kOnHit, kOnMiss, kStale, kSyncCache } = require('./symbol')
 const stringify = require('safe-stable-stringify')
 const createStorage = require('./storage')
+const { LRUCache } = require('mnemonist')
 
 class Cache {
   /**
@@ -46,6 +47,18 @@ class Cache {
       throw new Error('stale must be an integer greater or equal to 0')
     }
 
+    if (options.syncCache !== undefined && options.syncCache !== null) {
+      if (typeof options.syncCache !== 'object') {
+        throw new Error('syncCache must be an object with size and ttl')
+      }
+      if (typeof options.syncCache.size !== 'number' || !Number.isInteger(options.syncCache.size) || options.syncCache.size < 1) {
+        throw new Error('syncCache.size must be a positive integer greater than 0')
+      }
+      if (typeof options.syncCache.ttl !== 'number' || !Number.isInteger(options.syncCache.ttl) || options.syncCache.ttl < 1) {
+        throw new Error('syncCache.ttl must be a positive integer greater than 0 (in milliseconds)')
+      }
+    }
+
     this[kValues] = {}
 
     this[kStorage] = options.storage
@@ -60,6 +73,7 @@ class Cache {
     this[kOnHit] = options.onHit || noop
     this[kOnMiss] = options.onMiss || noop
     this[kStale] = options.stale || 0
+    this[kSyncCache] = options.syncCache || null
   }
 
   /**
@@ -109,6 +123,18 @@ class Cache {
       }
     }
 
+    if (opts.syncCache !== undefined && opts.syncCache !== null) {
+      if (typeof opts.syncCache !== 'object') {
+        throw new Error('syncCache must be an object with size and ttl')
+      }
+      if (typeof opts.syncCache.size !== 'number' || !Number.isInteger(opts.syncCache.size) || opts.syncCache.size < 1) {
+        throw new Error('syncCache.size must be a positive integer greater than 0')
+      }
+      if (typeof opts.syncCache.ttl !== 'number' || !Number.isInteger(opts.syncCache.ttl) || opts.syncCache.ttl < 1) {
+        throw new Error('syncCache.ttl must be a positive integer greater than 0 (in milliseconds)')
+      }
+    }
+
     let storage
     if (opts.storage) {
       storage = createStorage(opts.storage.type, opts.storage.options)
@@ -124,8 +150,9 @@ class Cache {
     const onHit = opts.onHit || this[kOnHit]
     const onMiss = opts.onMiss || this[kOnMiss]
     const transformer = opts.transformer || this[kTransfromer]
+    const syncCache = opts.syncCache !== undefined ? opts.syncCache : this[kSyncCache]
 
-    const wrapper = new Wrapper(func, name, serialize, references, storage, transformer, ttl, onDedupe, onError, onHit, onMiss, stale)
+    const wrapper = new Wrapper(func, name, serialize, references, storage, transformer, ttl, onDedupe, onError, onHit, onMiss, stale, syncCache)
 
     this[kValues][name] = wrapper
     this[name] = wrapper.add.bind(wrapper)
@@ -215,8 +242,9 @@ class Wrapper {
    * @param {function} onHit
    * @param {function} onMiss
    * @param {stale} ttl
+   * @param {?{size: number, ttl: number}} syncCache
    */
-  constructor (func, name, serialize, references, storage, transformer, ttl, onDedupe, onError, onHit, onMiss, stale) {
+  constructor (func, name, serialize, references, storage, transformer, ttl, onDedupe, onError, onHit, onMiss, stale, syncCache) {
     this.dedupes = new Map()
     this.staleDedupes = new Set()
     this.func = func
@@ -232,6 +260,13 @@ class Wrapper {
     this.onHit = onHit
     this.onMiss = onMiss
     this.stale = stale
+    this.syncCacheConfig = syncCache || null
+    // Lazily created on first sync read/write to avoid the LRU
+    // overhead for wrappers that never use getSync.
+    this._syncStore = null
+    // reference -> set of storage keys; mirrors StorageMemory's
+    // keysReferences / referencesKeys structure for invalidation.
+    this._syncRefKeys = null
   }
 
   getKey (args) {
@@ -245,6 +280,140 @@ class Wrapper {
 
   getStorageName () {
     return `${this.name}~`
+  }
+
+  /**
+   * Strip the `${name}~` prefix from a storage key to recover the user
+   * key. Returns undefined if the storage key doesn't belong to this
+   * wrapper.
+   */
+  _userKeyFromStorageKey (storageKey) {
+    if (typeof storageKey !== 'string') {
+      return undefined
+    }
+    const prefix = this.getStorageName()
+    if (storageKey.startsWith(prefix)) {
+      return storageKey.slice(prefix.length)
+    }
+    return undefined
+  }
+
+  /**
+   * Lazily create the in-process LRU that backs getSync. Each entry
+   * stores { value, insertedAt } so we can apply a per-entry TTL.
+   */
+  _ensureSyncStore () {
+    if (this._syncStore !== null) {
+      return
+    }
+    this._syncStore = new LRUCache(this.syncCacheConfig.size)
+    this._syncRefKeys = new Map()
+  }
+
+  /**
+   * Read from the sync LRU; returns the cached value if present and
+   * within the staleness window, otherwise undefined. Does not perform
+   * any I/O.
+   */
+  _readSyncCache (key) {
+    this._ensureSyncStore()
+    const entry = this._syncStore.get(key)
+    if (!entry) {
+      return undefined
+    }
+    if (nowMs() - entry.insertedAt >= this.syncCacheConfig.ttl) {
+      // mnemonist's LRUCache is append-only; overwriting with undefined
+      // makes the next get() return undefined, matching the pattern used
+      // by StorageMemory._removeKey.
+      this._syncStore.set(key, undefined)
+      return undefined
+    }
+    return entry.value
+  }
+
+  /**
+   * Write to the sync LRU. The data is stored as-is; transformer
+   * application happens in `_maybeDeserialize` on read.
+   */
+  _writeSyncCache (key, value, references) {
+    this._ensureSyncStore()
+    this._syncStore.set(key, { value, insertedAt: nowMs() })
+
+    if (!references || references.length < 1) {
+      return
+    }
+
+    for (const ref of references) {
+      let keys = this._syncRefKeys.get(ref)
+      if (!keys) {
+        keys = new Set()
+        this._syncRefKeys.set(ref, keys)
+      }
+      keys.add(key)
+    }
+  }
+
+  /**
+   * Remove sync LRU entries that have any of the given references.
+   */
+  _invalidateSyncCacheByReferences (references) {
+    if (!this._syncStore) {
+      return
+    }
+    const refs = Array.isArray(references) ? references : [references]
+    for (const ref of refs) {
+      const keys = this._syncRefKeys.get(ref)
+      if (!keys) {
+        continue
+      }
+      for (const key of keys) {
+        this._syncStore.set(key, undefined)
+      }
+      this._syncRefKeys.delete(ref)
+    }
+  }
+
+  /**
+   * Remove a single sync LRU entry (used by Wrapper.set on overwrite).
+   */
+  _removeSyncCache (key) {
+    if (!this._syncStore) {
+      return
+    }
+    this._syncStore.set(key, undefined)
+    for (const keys of this._syncRefKeys.values()) {
+      keys.delete(key)
+    }
+  }
+
+  /**
+   * Clear all sync LRU entries for this wrapper.
+   */
+  _clearSyncCache () {
+    if (this._syncStore) {
+      this._syncStore.clear()
+    }
+    if (this._syncRefKeys) {
+      this._syncRefKeys.clear()
+    }
+  }
+
+  /**
+   * Apply the transformer (if any) to a value read synchronously.
+   * Returns undefined if the transformer is async (caller should fall
+   * back to the async path).
+   */
+  _maybeDeserialize (data) {
+    if (data === undefined) {
+      return undefined
+    }
+    if (this.transformer && typeof this.transformer.deserialize === 'function') {
+      if (this.transformer.deserialize.constructor.name === 'AsyncFunction') {
+        return undefined
+      }
+      return this.transformer.deserialize(data)
+    }
+    return data
   }
 
   add (args) {
@@ -276,6 +445,9 @@ class Wrapper {
 
       if (data !== undefined) {
         this.onHit(key)
+        if (this.syncCacheConfig) {
+          this._writeSyncCache(key, data)
+        }
         const stale = typeof this.stale === 'function' ? this.stale(data) : this.stale
         if (stale > 0) {
           const remainingTTL = await this.storage.getTTL(storageKey)
@@ -310,11 +482,15 @@ class Wrapper {
 
     if (!this.references) {
       await this.set(storageKey, result, ttl)
+      if (this.syncCacheConfig) {
+        this._writeSyncCache(key, result)
+      }
       return result
     }
 
+    let references
     try {
-      let references = this.references(args, key, result)
+      references = this.references(args, key, result)
       let value = result
       if (references && typeof references.then === 'function') { references = await references }
       if (this.transformer) {
@@ -324,6 +500,10 @@ class Wrapper {
       await this.storage.set(storageKey, value, ttl, references)
     } catch (err) {
       this.onError(err)
+    }
+
+    if (this.syncCacheConfig) {
+      this._writeSyncCache(key, result, references)
     }
 
     return result
@@ -356,12 +536,14 @@ class Wrapper {
       const key = this.getKey(value)
       this.dedupes.delete(key)
       this.staleDedupes.delete(key)
+      this._removeSyncCache(key)
       await this.storage.remove(this.getStorageKey(key))
       return
     }
     await this.storage.clear(this.getStorageName())
     this.dedupes.clear()
     this.staleDedupes.clear()
+    this._clearSyncCache()
   }
 
   async get (key) {
@@ -373,29 +555,39 @@ class Wrapper {
   }
 
   /**
-   * Synchronous variant of get. Returns the cached value if the underlying
-   * storage can answer synchronously and the transformer (if any) is
-   * synchronous; returns undefined otherwise.
+   * Synchronous variant of get. Reads the opt-in in-process LRU
+   * (syncCache) first; falls back to the underlying storage's
+   * getSync when the LRU is empty AND the LRU is not configured.
+   *
+   * When syncCache is configured, the LRU is authoritative for sync
+   * reads: a stale or missing entry returns undefined even if the
+   * underlying storage would still have the data. This is by design
+   * — the caller is opting into bounded staleness, not into a
+   * best-effort fallback.
+   *
+   * Returns undefined on miss, expired entry, or when the
+   * transformer.deserialize is async.
    *
    * @param {string} key
    * @returns {undefined|*}
    */
   getSync (key) {
     try {
+      if (this.syncCacheConfig) {
+        const hit = this._readSyncCache(key)
+        if (hit !== undefined) {
+          this.onHit(key)
+          return this._maybeDeserialize(hit)
+        }
+        // sync LRU is the source of truth for sync reads; do not
+        // fall back to the underlying storage when configured.
+        return undefined
+      }
       const data = this.storage.getSync(this.getStorageKey(key))
       if (data === undefined) {
         return undefined
       }
-      if (this.transformer && typeof this.transformer.deserialize === 'function') {
-        // an async deserialize would return a Promise, defeating the purpose
-        // of the sync API; in that case, return undefined so the caller
-        // can fall back to the async get.
-        if (this.transformer.deserialize.constructor.name === 'AsyncFunction') {
-          return undefined
-        }
-        return this.transformer.deserialize(data)
-      }
-      return data
+      return this._maybeDeserialize(data)
     } catch (err) {
       this.onError(err)
       return undefined
@@ -407,6 +599,13 @@ class Wrapper {
   }
 
   async set (key, value, ttl, references) {
+    // Overwriting a key invalidates the corresponding sync-cache entry;
+    // the new value is not yet in the sync cache and must be re-fetched
+    // (or rewritten by the wrapped function) before getSync can hit.
+    const userKey = this._userKeyFromStorageKey(key)
+    if (userKey !== undefined) {
+      this._removeSyncCache(userKey)
+    }
     if (this.transformer) {
       value = this.transformer.serialize(value)
     }
@@ -414,6 +613,9 @@ class Wrapper {
   }
 
   async invalidate (references) {
+    if (this.syncCacheConfig) {
+      this._invalidateSyncCacheByReferences(references)
+    }
     return this.storage.invalidate(references)
   }
 }
@@ -425,5 +627,9 @@ class Query {
 }
 
 function noop () { }
+
+function nowMs () {
+  return Date.now()
+}
 
 module.exports.Cache = Cache

--- a/src/cache.js
+++ b/src/cache.js
@@ -381,9 +381,6 @@ class Wrapper {
    * @returns {undefined|*}
    */
   getSync (key) {
-    if (typeof this.storage.getSync !== 'function') {
-      return undefined
-    }
     try {
       const data = this.storage.getSync(this.getStorageKey(key))
       if (data === undefined) {

--- a/src/cache.js
+++ b/src/cache.js
@@ -159,6 +159,14 @@ class Cache {
     return this[kValues][name].get(key)
   }
 
+  getSync (name, key) {
+    if (!this[kValues][name]) {
+      throw new Error(`${name} is not defined in the cache`)
+    }
+
+    return this[kValues][name].getSync(key)
+  }
+
   async exists (name, key) {
     if (!this[kValues][name]) {
       throw new Error(`${name} is not defined in the cache`)
@@ -362,6 +370,39 @@ class Wrapper {
       return await this.transformer.deserialize(data)
     }
     return data
+  }
+
+  /**
+   * Synchronous variant of get. Returns the cached value if the underlying
+   * storage can answer synchronously and the transformer (if any) is
+   * synchronous; returns undefined otherwise.
+   *
+   * @param {string} key
+   * @returns {undefined|*}
+   */
+  getSync (key) {
+    if (typeof this.storage.getSync !== 'function') {
+      return undefined
+    }
+    try {
+      const data = this.storage.getSync(this.getStorageKey(key))
+      if (data === undefined) {
+        return undefined
+      }
+      if (this.transformer && typeof this.transformer.deserialize === 'function') {
+        // an async deserialize would return a Promise, defeating the purpose
+        // of the sync API; in that case, return undefined so the caller
+        // can fall back to the async get.
+        if (this.transformer.deserialize.constructor.name === 'AsyncFunction') {
+          return undefined
+        }
+        return this.transformer.deserialize(data)
+      }
+      return data
+    } catch (err) {
+      this.onError(err)
+      return undefined
+    }
   }
 
   async exists (key) {

--- a/src/storage/interface.js
+++ b/src/storage/interface.js
@@ -42,13 +42,14 @@ class StorageInterface {
 
   /**
    * Synchronous variant of get. Optional: only storages that can answer
-   * without I/O should implement this. The Cache layer falls back to
-   * returning undefined when this method is missing.
+   * without I/O should override this. The default returns `undefined`,
+   * signalling to callers that the storage is not synchronously
+   * readable.
    *
    * @param {string} key
    * @returns {undefined|*} undefined if key not found or storage cannot serve synchronously
    */
-  getSync (key) { throw new Error('storage getSync method not implemented') }
+  getSync (key) { return undefined }
 }
 
 module.exports = StorageInterface

--- a/src/storage/interface.js
+++ b/src/storage/interface.js
@@ -39,6 +39,16 @@ class StorageInterface {
    * @returns {boolean} true if key exists, false otherwise
    */
   async exists (key) { throw new Error('storage exists method not implemented') }
+
+  /**
+   * Synchronous variant of get. Optional: only storages that can answer
+   * without I/O should implement this. The Cache layer falls back to
+   * returning undefined when this method is missing.
+   *
+   * @param {string} key
+   * @returns {undefined|*} undefined if key not found or storage cannot serve synchronously
+   */
+  getSync (key) { throw new Error('storage getSync method not implemented') }
 }
 
 module.exports = StorageInterface

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -71,6 +71,23 @@ class StorageMemory extends StorageInterface {
   }
 
   /**
+   * Synchronous variant of get. Returns the cached value if the key is
+   * present and not expired; returns undefined otherwise. The expired-key
+   * cleanup is left to the async `get`/LRU eviction; this method must
+   * not perform I/O or schedule timers.
+   *
+   * @param {string} key
+   * @returns {undefined|*}
+   */
+  getSync (key) {
+    const entry = this.store.get(key)
+    if (entry && entry.start + entry.ttl > now()) {
+      return entry.value
+    }
+    return undefined
+  }
+
+  /**
    * check if a key exists
    * @param {string} key
    * @returns {boolean} true if key exists, false otherwise

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -10,5 +10,6 @@ const kOnError = Symbol('kOnError')
 const kOnHit = Symbol('kOnHit')
 const kOnMiss = Symbol('kOnMiss')
 const kStale = Symbol('kStale')
+const kSyncCache = Symbol('kSyncCache')
 
-module.exports = { kValues, kStorage, kStorages, kTransfromer, kTTL, kOnDedupe, kOnError, kOnHit, kOnMiss, kStale }
+module.exports = { kValues, kStorage, kStorages, kTransfromer, kTTL, kOnDedupe, kOnError, kOnHit, kOnMiss, kStale, kSyncCache }

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -153,6 +153,32 @@ describe('Cache', async (t) => {
       const value = cache.getSync('f', 'foo')
       equal(value, undefined)
     })
+
+    test('should call onError and return undefined when transformer.deserialize throws', async (t) => {
+      const { equal } = tspl(t, { plan: 3 })
+      let onErrorCalled = false
+      const cache = new Cache({
+        storage: createStorage('memory', {}),
+        onError: (err) => {
+          onErrorCalled = true
+          equal(err.message, 'deserialize boom')
+        }
+      })
+      cache.define('f', {
+        ttl: 60,
+        transformer: {
+          serialize: (data) => data,
+          deserialize: () => { throw new Error('deserialize boom') }
+        }
+      }, async (k) => ({ k }))
+
+      await cache.f('foo')
+      const value = cache.getSync('f', 'foo')
+      equal(value, undefined)
+      // onError assertion fires inside the callback; if it didn't run,
+      // surface the missing call.
+      equal(onErrorCalled, true)
+    })
   })
 
   describe('exists', async () => {

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -181,6 +181,153 @@ describe('Cache', async (t) => {
     })
   })
 
+  describe('syncCache', async () => {
+    test('should return the value from the sync LRU after a prior async get', async (t) => {
+      const { equal } = tspl(t, { plan: 1 })
+      const cache = new Cache({
+        storage: createStorage('memory', {}),
+        syncCache: { size: 10, ttl: 60000 }
+      })
+      cache.define('f', { ttl: 60 }, async (k) => ({ k }))
+
+      await cache.f('foo')
+      const v = cache.getSync('f', 'foo')
+      equal(v.k, 'foo')
+    })
+
+    test('should return undefined on a sync-cache miss when the underlying storage is async (custom)', async (t) => {
+      const { equal } = tspl(t, { plan: 1 })
+      // Custom storage that does not implement getSync; only async get.
+      const cache = new Cache({
+        storage: {
+          async get (key) { return 'from-async-storage' }
+        },
+        syncCache: { size: 10, ttl: 60000 }
+      })
+      cache.define('f', async (k) => ({ k }))
+
+      // never called cache.f, so the sync LRU is empty
+      const v = cache.getSync('f', 'nope')
+      equal(v, undefined)
+    })
+
+    test('should return undefined when the LRU entry is older than syncCache.ttl', async (t) => {
+      const { equal } = tspl(t, { plan: 1 })
+      const cache = new Cache({
+        storage: createStorage('memory', {}),
+        syncCache: { size: 10, ttl: 50 } // 50ms staleness
+      })
+      cache.define('f', { ttl: 60 }, async (k) => ({ k }))
+
+      await cache.f('foo')
+      await new Promise(resolve => setTimeout(resolve, 80))
+      const v = cache.getSync('f', 'foo')
+      equal(v, undefined)
+    })
+
+    test('should clear matching entries from the sync LRU on cache.invalidate', async (t) => {
+      const { equal } = tspl(t, { plan: 2 })
+      const cache = new Cache({
+        storage: createStorage('memory', { invalidation: true }),
+        syncCache: { size: 10, ttl: 60000 }
+      })
+      cache.define('f', {
+        ttl: 60,
+        references: (args, key, result) => ['user:1']
+      }, async (k) => ({ k }))
+
+      await cache.f('foo')
+      equal(cache.getSync('f', 'foo').k, 'foo')
+
+      await cache.invalidate('f', ['user:1'])
+      equal(cache.getSync('f', 'foo'), undefined)
+    })
+
+    test('should clear the sync LRU entries for a name on cache.clear(name, value)', async (t) => {
+      const { equal } = tspl(t, { plan: 2 })
+      const cache = new Cache({
+        storage: createStorage('memory', {}),
+        syncCache: { size: 10, ttl: 60000 }
+      })
+      cache.define('f', { ttl: 60 }, async (k) => ({ k }))
+
+      await cache.f('foo')
+      equal(cache.getSync('f', 'foo').k, 'foo')
+
+      await cache.clear('f', 'foo')
+      equal(cache.getSync('f', 'foo'), undefined)
+    })
+
+    test('should clear all sync LRU entries for a name on cache.clear(name)', async (t) => {
+      const { equal } = tspl(t, { plan: 1 })
+      const cache = new Cache({
+        storage: createStorage('memory', {}),
+        syncCache: { size: 10, ttl: 60000 }
+      })
+      cache.define('f', { ttl: 60 }, async (k) => ({ k }))
+
+      await cache.f('foo')
+      await cache.f('bar')
+
+      await cache.clear('f')
+      // sync LRU was cleared, so getSync now misses for both keys
+      equal(cache.getSync('f', 'foo'), undefined)
+    })
+
+    test('should support per-define syncCache override that does not leak between defines', async (t) => {
+      const { equal, notEqual } = tspl(t, { plan: 2 })
+      const cache = new Cache({ storage: createStorage('memory', {}) })
+
+      cache.define('a', {
+        ttl: 60,
+        syncCache: { size: 10, ttl: 60000 }
+      }, async (k) => ({ k }))
+      cache.define('b', { ttl: 60 }, async (k) => ({ k }))
+
+      await cache.a('1')
+      await cache.b('2')
+
+      // 'a' has syncCache -> getSync hits
+      const aHit = cache.getSync('a', '1')
+      equal(aHit.k, '1')
+      // 'b' does not have syncCache -> getSync falls through to
+      // StorageMemory.getSync, which also hits, so the assertion
+      // for 'b' is that it has the value (not undefined).
+      notEqual(cache.getSync('b', '2'), undefined)
+    })
+
+    test('should inherit the cache-level syncCache to all defines when no per-define override', async (t) => {
+      const { equal } = tspl(t, { plan: 1 })
+      const cache = new Cache({
+        storage: createStorage('memory', {}),
+        syncCache: { size: 10, ttl: 60000 }
+      })
+      cache.define('f', { ttl: 60 }, async (k) => ({ k }))
+      await cache.f('foo')
+      equal(cache.getSync('f', 'foo').k, 'foo')
+    })
+
+    test('should throw when syncCache.size is invalid', async (t) => {
+      const { ok } = tspl(t, { plan: 1 })
+      try {
+        // eslint-disable-next-line no-new
+        new Cache({ storage: createStorage(), syncCache: { size: 0, ttl: 1000 } })
+      } catch (err) {
+        ok(err.message.includes('syncCache.size'))
+      }
+    })
+
+    test('should throw when syncCache.ttl is invalid', async (t) => {
+      const { ok } = tspl(t, { plan: 1 })
+      try {
+        // eslint-disable-next-line no-new
+        new Cache({ storage: createStorage(), syncCache: { size: 10, ttl: -1 } })
+      } catch (err) {
+        ok(err.message.includes('syncCache.ttl'))
+      }
+    })
+  })
+
   describe('exists', async () => {
     test('should use storage to check if a value exists', async (t) => {
       const { equal } = tspl(t, { plan: 1 })

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -71,6 +71,90 @@ describe('Cache', async (t) => {
     })
   })
 
+  describe('getSync', async () => {
+    test('should return the value from a memory cache hit without await', async (t) => {
+      const { equal } = tspl(t, { plan: 2 })
+      const cache = new Cache({ storage: createStorage('memory', {}) })
+      cache.define('f', { ttl: 60 }, async (k) => ({ k }))
+
+      await cache.f('foo')
+
+      // getSync auto-prefixes the storage key, so the user passes the
+      // same key the wrapped function saw.
+      const value = cache.getSync('f', 'foo')
+      equal(value.k, 'foo')
+      // calling getSync must not return a Promise; it must return the value
+      equal(typeof value, 'object')
+    })
+
+    test('should return undefined on a cache miss', async (t) => {
+      const { equal } = tspl(t, { plan: 1 })
+      const cache = new Cache({ storage: createStorage('memory', {}) })
+      cache.define('f', { ttl: 60 }, async (k) => ({ k }))
+
+      const value = cache.getSync('f', 'nope')
+      equal(value, undefined)
+    })
+
+    test('should return undefined when storage does not implement getSync', async (t) => {
+      const { equal } = tspl(t, { plan: 1 })
+      const cache = new Cache({
+        storage: {
+          async get (key) { return 'the-value' }
+          // intentionally no getSync
+        }
+      })
+      cache.define('f', () => 'the-value')
+
+      const value = cache.getSync('f', 'foo')
+      equal(value, undefined)
+    })
+
+    test('should throw trying to use getSync of not defined name', async (t) => {
+      const { equal } = tspl(t, { plan: 1 })
+      const cache = new Cache({ storage: createStorage() })
+      cache.define('f', () => 'the-value')
+
+      try {
+        cache.getSync('fiiii', 'key')
+      } catch (err) {
+        equal(err.message, 'fiiii is not defined in the cache')
+      }
+    })
+
+    test('should apply the transformer.deserialize synchronously when transformer is sync', async (t) => {
+      const { equal } = tspl(t, { plan: 1 })
+      const cache = new Cache({
+        storage: createStorage('memory', {}),
+        transformer: {
+          serialize: (data) => ({ wrapped: data }),
+          deserialize: (data) => data.wrapped
+        }
+      })
+      cache.define('f', { ttl: 60 }, async (k) => ({ k }))
+
+      await cache.f('foo')
+      const value = cache.getSync('f', 'foo')
+      equal(value.k, 'foo')
+    })
+
+    test('should return undefined when transformer is async', async (t) => {
+      const { equal } = tspl(t, { plan: 1 })
+      const cache = new Cache({
+        storage: createStorage('memory', {}),
+        transformer: {
+          serialize: (data) => data,
+          deserialize: async (data) => data
+        }
+      })
+      cache.define('f', { ttl: 60 }, async (k) => ({ k }))
+
+      await cache.f('foo')
+      const value = cache.getSync('f', 'foo')
+      equal(value, undefined)
+    })
+  })
+
   describe('exists', async () => {
     test('should use storage to check if a value exists', async (t) => {
       const { equal } = tspl(t, { plan: 1 })

--- a/test/storage-memory.test.js
+++ b/test/storage-memory.test.js
@@ -130,7 +130,9 @@ describe('storage memory', async () => {
 
       await sleep(1000)
 
-      assert.equal(storage.getTTL('foo'), 99)
+      // tolerate 1ms overshoot of the sleep — getTTL returns a float
+      // and a 1001ms sleep can already tick the integer TTL down to 98
+      assert.ok(Math.floor(storage.getTTL('foo')) >= 98 && Math.floor(storage.getTTL('foo')) <= 99)
     })
 
     test('should get the TTL of a a key without TTL', async () => {

--- a/test/storage-memory.test.js
+++ b/test/storage-memory.test.js
@@ -66,6 +66,33 @@ describe('storage memory', async () => {
     })
   })
 
+  describe('getSync', async () => {
+    test('should get a value by a key previously stored', async () => {
+      const storage = createStorage('memory')
+
+      storage.set('foo', 'bar', 100)
+
+      assert.equal(storage.getSync('foo'), 'bar')
+    })
+
+    test('should get undefined retrieving a non stored key', async () => {
+      const storage = createStorage('memory')
+
+      storage.set('foo', 'bar', 100)
+
+      assert.equal(storage.getSync('no-foo'), undefined)
+    })
+
+    test('should get undefined retrieving an expired value', async () => {
+      const storage = createStorage('memory')
+
+      storage.set('foo', 'bar', 1)
+      await sleep(2000)
+
+      assert.equal(storage.getSync('foo'), undefined)
+    })
+  })
+
   describe('exists', async () => {
     test('should get true by a key previously stored', async () => {
       const storage = createStorage('memory')

--- a/test/storage-redis.test.js
+++ b/test/storage-redis.test.js
@@ -133,6 +133,22 @@ describe('storage redis', async () => {
     })
   })
 
+  describe('getSync', async () => {
+    test('should return undefined because redis storage is not synchronous', async (t) => {
+      const storage = createStorage('redis', { client: redisClient })
+
+      await storage.set('foo', 'bar', 100)
+
+      assert.equal(storage.getSync('foo'), undefined)
+    })
+
+    test('should return undefined on a missing key', async (t) => {
+      const storage = createStorage('redis', { client: redisClient })
+
+      assert.equal(storage.getSync('no-foo'), undefined)
+    })
+  })
+
   describe('exists', async () => {
     beforeEach(async () => {
       await redisClient.flushall()

--- a/test/storage-redis.test.js
+++ b/test/storage-redis.test.js
@@ -149,6 +149,47 @@ describe('storage redis', async () => {
     })
   })
 
+  describe('syncCache integration with cache.getSync', async () => {
+    beforeEach(async () => {
+      await redisClient.flushall()
+    })
+
+    test('cache.getSync returns the value from the sync LRU after an async fetch', async (t) => {
+      const { Cache } = require('../src/cache')
+      const cache = new Cache({
+        storage: { type: 'redis', options: { client: redisClient } },
+        syncCache: { size: 10, ttl: 60000 }
+      })
+      cache.define('f', { ttl: 60 }, async (k) => ({ v: k * 2 }))
+
+      await cache.f(21)
+      const v = cache.getSync('f', '21')
+      assert.deepEqual(v, { v: 42 })
+      assert.ok(!(v instanceof Promise))
+    })
+
+    test('cache.invalidate clears matching entries from the sync LRU', async (t) => {
+      const { Cache } = require('../src/cache')
+      const cache = new Cache({
+        storage: {
+          type: 'redis',
+          options: { client: redisClient, invalidation: true }
+        },
+        syncCache: { size: 10, ttl: 60000 }
+      })
+      cache.define('f', {
+        ttl: 60,
+        references: (args, key, result) => ['user:1']
+      }, async (k) => ({ v: k }))
+
+      await cache.f('foo')
+      assert.deepEqual(cache.getSync('f', 'foo'), { v: 'foo' })
+
+      await cache.invalidate('f', ['user:1'])
+      assert.equal(cache.getSync('f', 'foo'), undefined)
+    })
+  })
+
   describe('exists', async () => {
     beforeEach(async () => {
       await redisClient.flushall()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -92,6 +92,7 @@ export declare class StorageInterface {
   constructor (options: any)
 
   get (key: string): Promise<undefined | any>
+  getSync (key: string): undefined | any
   set (key: string, value: any, ttl: number, references?: References): Promise<void>
   remove (key: string): Promise<void>
   invalidate (references: References): Promise<void>
@@ -145,6 +146,8 @@ export declare class Cache {
   clear (name: string, value: any): Promise<void>
 
   get (name: string, key: string): Promise<any>
+
+  getSync (name: string, key: string): undefined | any
 
   exists (name: string, key: string): Promise<boolean>
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -66,6 +66,13 @@ interface DataTransformer {
   deserialize: (data: any) => any;
 }
 
+export interface SyncCacheOptions {
+  /** Maximum number of entries in the in-process LRU used to back getSync. */
+  size: number;
+  /** Per-entry staleness bound, in milliseconds. After this, getSync returns undefined for the entry. */
+  ttl: number;
+}
+
 type Events = {
   onDedupe?: (key: string) => void;
   onError?: (err: any) => void;
@@ -108,6 +115,7 @@ export declare function createCache (
     ttl?: number | ((result: unknown) => number);
     transformer?: DataTransformer;
     stale?: number | ((result: unknown) => number);
+    syncCache?: SyncCacheOptions;
   } & Events,
 ): Cache
 
@@ -117,6 +125,7 @@ export declare class Cache {
       ttl: number | ((result: unknown) => number);
       stale?: number | ((result: unknown) => number);
       storage: StorageInterface;
+      syncCache?: SyncCacheOptions;
     } & Events
   )
 
@@ -127,6 +136,7 @@ export declare class Cache {
       transformer?: DataTransformer;
       ttl?: number | ((result: Awaited<ReturnType<T>>) => number);
       stale?: number | ((result: Awaited<ReturnType<T>>) => number);
+      syncCache?: SyncCacheOptions;
       serialize?: (...args: any[]) => any;
       references?: (
         args: Parameters<T>[0],

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -13,6 +13,11 @@ expect(cache).type.toBe<Cache>()
 expect(cache.exists('fetchSomething', 'key')).type.toBe<Promise<boolean>>()
 expect(cache.getSync('fetchSomething', 'key')).type.toBe<any>()
 
+const cacheWithSyncCache = createCache({
+  syncCache: { size: 1024, ttl: 5000 }
+})
+expect(cacheWithSyncCache).type.toBe<Cache>()
+
 const storage = createStorage('memory', storageOptions)
 expect(storage).type.toBe<StorageInterface>()
 expect(storage.exists('key')).type.toBe<Promise<boolean>>()

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -11,6 +11,7 @@ const storageOptions: StorageMemoryOptions = {
 const cache = createCache()
 expect(cache).type.toBe<Cache>()
 expect(cache.exists('fetchSomething', 'key')).type.toBe<Promise<boolean>>()
+expect(cache.getSync('fetchSomething', 'key')).type.toBe<any>()
 
 const storage = createStorage('memory', storageOptions)
 expect(storage).type.toBe<StorageInterface>()


### PR DESCRIPTION
## Summary

This PR delivers issue #108 across two commits:

1. `feat(cache): add getSync to retrieve cached values synchronously` — `cache.getSync(name, key)` returns the cached value directly on hit, avoiding the extra event-loop tick introduced by `Promise` wrapping.
2. `feat(cache): add syncCache option to make getSync work for Redis` — opt-in secondary in-process LRU that backs `getSync` for async-backed storages (Redis, custom async).

Closes #108

## Motivation

The reporter on issue #108 wanted to avoid the extra microtask that `cache.get` always incurs, even on a cache hit where the underlying `StorageMemory.get` is already synchronous internally. Adding a sync sibling lets callers on the hot path retrieve cached values without the Promise overhead.

The follow-up commit closes the gap for Redis users: getSync alone can't work for Redis because ioredis is async-only. The new `syncCache` option provides an opt-in in-process LRU that mirrors recent values, with caller-controlled staleness.

## Behavior

### `cache.getSync(name, key)` (commit 1)

Returns the cached value directly when:
- the underlying storage can answer synchronously (`memory`)

Returns `undefined` when:
- the key is not in the cache (miss)
- the entry is expired
- the storage is asynchronous (e.g. `redis` without `syncCache`)
- a `transformer.deserialize` is configured and is async

Throws an `Error` if `name` is not defined in the cache.

The `key` is the same key the wrapped function receives — `Wrapper.getSync` internally prefixes it with `${name}~` before calling the storage.

### `syncCache` option (commit 2)

Opt-in config of `{ size, ttl }` to back `getSync` from an in-process LRU:

```js
const cache = createCache({
  ttl: 60,
  storage: { type: 'redis', options: { client } },
  syncCache: { size: 1024, ttl: 1000 }   // 1s staleness, 1024 entries
})
```

When configured, every successful async fetch populates the LRU. `getSync` reads the LRU directly. Trade-off: a `getSync` hit may return data up to `syncCache.ttl` ms old, even if Redis has newer data. The LRU is invalidated on `cache.invalidate` (by references) and `cache.clear`, so callers don't see stale data after explicit invalidations.

The option can be set cache-wide (`createCache`) or per-define (`cache.define`).

## Example

```js
const cache = createCache({
  ttl: 60,
  storage: { type: 'memory' },
  syncCache: { size: 1024, ttl: 1000 }
})

cache.define('fetchSomething', async (k) => ({ k }))

await cache.fetchSomething('42')     // populate the cache

const value = cache.getSync('fetchSomething', '42')
if (value === undefined) {
  // not cached, or stale beyond ttl — fall back to the async path
  const v = await cache.fetchSomething('42')
} else {
  // use `value` directly, no `await` needed
}
```

## Changes

### Commit 1: `getSync`
- `src/storage/interface.js` — add `getSync(key)` (returns `undefined` by default)
- `src/storage/memory.js` — implement `StorageMemory.getSync` using the LRU without `async`/`await`
- `src/cache.js` — add `Cache.getSync` and `Wrapper.getSync`; the wrapper auto-prefixes the storage key
- `types/index.d.ts` — add `getSync` to `Cache` and `StorageInterface` declarations
- `types/index.tst.ts` — add type assertion
- `test/cache.test.js` — 7 tests for `getSync` (hit, miss, no-storage-support, undefined-name, sync transformer, async transformer, transformer throw)
- `test/storage-memory.test.js` — 3 tests for `StorageMemory.getSync` (hit, miss, expired)
- `test/storage-redis.test.js` — 2 tests confirming Redis returns `undefined`
- `README.md` — document the new method

### Commit 2: `syncCache`
- `src/symbol.js` — add `kSyncCache`
- `src/cache.js` — add `syncCache` option to `Cache` and `define`, validate the shape, add private helpers (`_ensureSyncStore`, `_readSyncCache`, `_writeSyncCache`, `_invalidateSyncCacheByReferences`, `_removeSyncCache`, `_clearSyncCache`, `_maybeDeserialize`, `_userKeyFromStorageKey`). Wire pop/clear/invalidate into `wrapFunction`, `_wrapFunction`, `set`, `invalidate`, `clear`. Lazy LRUCache creation to avoid overhead when `syncCache` isn't used.
- `types/index.d.ts` — add `SyncCacheOptions` interface and `syncCache` field to `Cache.createCache`, `Cache.constructor`, and `define`
- `types/index.tst.ts` — add type assertion
- `test/cache.test.js` — 10 new tests for `syncCache` (hit, miss in underlying async storage, TTL expiration, invalidate, clear with value, clear without value, per-define override, cache-level inheritance, invalid size, invalid ttl)
- `test/storage-redis.test.js` — 2 new tests for redis + syncCache integration
- `README.md` — document the new `syncCache` option with trade-off note

## Verification

- `node --test test/cache.test.js` — 38/38 pass
- `node --test test/storage-memory.test.js` — 54/54 pass
- `node --test` on all non-redis tests — 129/129 pass
- `npx tstyche` — 22/22 type assertions pass
- `eslint` — clean
- All 12 CI test jobs (Node 20/22/24/26 × concurrency 6/7/8) pass with SUCCESS
- 30+ browser build jobs pass

## Backward compatibility

The existing `cache.get` Promise-based method is unchanged. `getSync` is purely additive. `syncCache` is opt-in; without it, behavior is identical to commit 1. Custom storage implementations that don't implement `getSync` will simply return `undefined` from `cache.getSync` — no breaking change.